### PR TITLE
Use a more advanced store with derived statistics

### DIFF
--- a/src/components/SequenceViewer.js
+++ b/src/components/SequenceViewer.js
@@ -34,11 +34,11 @@ class SequenceViewerComponent extends DraggingComponent {
     const tileHeight = this.props.tileHeight;
     const xInitPos = -(this.props.position.xPos % tileWidth);
     let yPos = -(this.props.position.yPos % tileHeight);
-    let i = this.currentViewSequence();
+    let i = this.props.stats.currentViewSequence;
     for (; i < sequences.length; i++) {
       const sequence = sequences[i].sequence;
       let xPos = xInitPos;
-      let j = this.currentViewSequencePosition(sequence);
+      let j = Math.min(sequence.length, this.props.stats.currentViewSequencePosition);
       for (; j < sequence.length; j++) {
         const el = sequence[j];
         this.ctx.font(this.props.tileFont);
@@ -71,23 +71,6 @@ class SequenceViewerComponent extends DraggingComponent {
     const maxHeight = this.props.sequences.raw.length * this.props.tileHeight - this.props.height;
     pos.yPos = clamp(pos.yPos, 0, maxHeight);
     this.props.updatePosition(pos);
-  }
-
-  // TODO: move into the reducer
-  /**
-   * Returns the first visible sequence on the current viewpoint.
-   * Might only be partially visible.
-   */
-  currentViewSequence() {
-    return clamp(floor(this.props.position.yPos / this.props.tileHeight), 0, this.props.sequences.length - 1)
-  }
-
-  /**
-   * Returns the first visible position on the current viewpoint.
-   * Might only be partially visible.
-   */
-  currentViewSequencePosition(sequence) {
-    return clamp(floor(this.props.position.xPos / this.props.tileWidth), 0, sequence.length - 1);
   }
 
   positionToSequence(pos) {
@@ -236,6 +219,7 @@ const mapStateToProps = state => {
     msecsPerFps: state.props.msecsPerFps,
     colorScheme: state.props.colorScheme,
     engine: state.props.engine,
+    stats: state.sequenceStats,
   }
 }
 

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -6,35 +6,39 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-export const types = {
-  POSITION_UPDATE: 'POSITION_UPDATE',
-  PROPS_UPDATE: 'PROPS_UPDATE',
-  SEQUENCES_UPDATE: 'SEQUENCES_UPDATE',
-};
-
 /**
  * Creates a redux action of the following payload:
  * {
  *  type,
- *  ...forwardedArgNames,
+ *  payload: ...forwardedArgNames,
  * }
  * i.e. its payload is the given `type` and the forwarded argument names from the actions payload.
- * If no arguments are provided, the payload is forwarded as `data`.
+ * If no arguments are provided, the payload is forwarded as `payload` in accordance to FSA (Flux Standard Action).
+ *
+ * Similar to createAction from redux-actions
  */
-function makeActionCreator(type, ...argNames) {
-  return function (...args) {
-    const action = { type };
+function createAction(type, ...argNames) {
+  const actionCreator = function (...args) {
+    let payload;
     if (argNames.length === 0) {
-      action.data = args[0];
-      return action;
+      payload = args[0];
+    } else {
+      payload = {};
+      argNames.forEach((arg, index) => {
+        payload[argNames[index]] = args[index];
+      });
     }
-    argNames.forEach((arg, index) => {
-      action[argNames[index]] = args[index];
-    });
-    return action;
+    return {
+      type,
+      payload,
+    }
   }
+  actionCreator.toString = () => type.toString();
+  actionCreator.key = actionCreator.toString();
+  return actionCreator;
 }
 
-export const updatePosition = makeActionCreator(types.POSITION_UPDATE);
-export const updateProps = makeActionCreator(types.PROPS_UPDATE, 'key', 'value');
-export const updateSequences = makeActionCreator(types.SEQUENCES_UPDATE);
+// TODO: maybe use createActions from redux-actions here
+export const updatePosition = createAction('POSITION_UPDATE');
+export const updateProps = createAction('PROPS_UPDATE', 'key', 'value');
+export const updateSequences = createAction('SEQUENCES_UPDATE');

--- a/src/store/createMSAStore.js
+++ b/src/store/createMSAStore.js
@@ -10,12 +10,19 @@ import PropTypes from 'prop-types';
 
 import { createStore } from 'redux'
 
-import { merge } from 'lodash-es';
+import {
+  each,
+  merge,
+} from 'lodash-es';
 
 import { MSAPropTypes, msaDefaultProps } from '../PropTypes';
 
 import positionReducers from '../store/reducers';
-import calculateSequencesState from './calculateSequencesState';
+import {
+  updateProps,
+  updatePosition,
+  updateSequences,
+} from '../store/actions';
 
 /**
 Initializes a new MSAViewer store-like structure.
@@ -27,12 +34,13 @@ export const createMSAStore = (props) => {
   PropTypes.checkPropTypes(MSAPropTypes, props, 'prop', 'MSAViewer');
   const propsWithDefaultValues = merge({}, msaDefaultProps, props);
   const {sequences, position, ...otherProps} = propsWithDefaultValues;
-  const customProps = {
-    props: otherProps,
-    position,
-    sequences: calculateSequencesState(props.sequences),
-  };
-  return createStore(positionReducers, customProps);
+  const store = createStore(positionReducers);
+  each(otherProps, (v, k) => {
+    store.dispatch(updateProps(k, v));
+  });
+  store.dispatch(updatePosition(position));
+  store.dispatch(updateSequences(sequences));
+  return store;
 }
 
 export default createMSAStore;

--- a/src/store/createMSAStore.js
+++ b/src/store/createMSAStore.js
@@ -34,7 +34,10 @@ export const createMSAStore = (props) => {
   PropTypes.checkPropTypes(MSAPropTypes, props, 'prop', 'MSAViewer');
   const propsWithDefaultValues = merge({}, msaDefaultProps, props);
   const {sequences, position, ...otherProps} = propsWithDefaultValues;
-  const store = createStore(positionReducers);
+  const store = createStore(positionReducers,
+    // https://github.com/zalmoxisus/redux-devtools-extension
+    window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+  );
   each(otherProps, (v, k) => {
     store.dispatch(updateProps(k, v));
   });

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -79,7 +79,6 @@ const sequenceStats = (prevState = {
     case actions.updateProps.key:
     case actions.updatePosition.key:
     case actions.updateSequences.key:
-      console.log("a");
       if (state.props && state.props.tileHeight && state.props.tileWidth &&
           state.position && state.sequences) {
         const stats = {};
@@ -93,7 +92,6 @@ const sequenceStats = (prevState = {
           0,
           state.sequences.maxLength,
         );
-        console.log(stats);
         return stats;
       }
       break;

--- a/src/store/reducers/calculateSequencesState.js
+++ b/src/store/reducers/calculateSequencesState.js
@@ -10,7 +10,7 @@ import {
   reduce,
 } from 'lodash-es';
 
-const calculateSequencesState = (sequences) => {
+const calculateSequencesState = (prevState, sequences) => {
   const state = {
     raw: sequences,
     length: sequences.length,

--- a/src/store/reducers/combineReducers.js
+++ b/src/store/reducers/combineReducers.js
@@ -1,0 +1,47 @@
+/**
+* Copyright 2018, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+/**
+ * Own implementation of combineReducers which allows manipulating the state
+ * afterwards
+ * See:
+ *  - https://github.com/reduxjs/redux/blob/master/docs/recipes/reducers/UsingCombineReducers.md
+ *  - https://github.com/reduxjs/redux/blob/master/src/combineReducers.js
+ *
+ * Turns an object whose values are different reducer functions, into a single
+ * reducer function. It will call every child reducer, and gather their results
+ * into a single state object, whose keys correspond to the keys of the passed
+ * reducer functions.
+ *
+ * @param {Object} reducers An object whose values correspond to different
+ * reducer functions that need to be combined into one. One handy way to obtain
+ * it is to use ES6 `import * as reducers` syntax. The reducers may never return
+ * undefined for any action. Instead, they should return their initial state
+ * if the state passed to them was undefined, and the current state for any
+ * unrecognized action.
+ *
+ * @returns {Function} A reducer function that invokes every reducer inside the
+ * passed object, and builds a state object with the same shape.
+ */
+export default function combineReducers(reducers) {
+  const keys = Object.keys(reducers);
+  return function(state = {}, action) {
+    const nextState = {};
+    let hasChanged = false;
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      const nextStateForKey = reducers[key](state[key], action);
+      if (typeof nextStateForKey === 'undefined') {
+        throw new Error("A reducer can't return 'undefined'");
+      }
+      nextState[key] = nextStateForKey;
+      hasChanged = hasChanged || nextStateForKey !== state[key];
+    }
+    return hasChanged ? nextState : state;
+  };
+};

--- a/src/store/reducers/handleActions.js
+++ b/src/store/reducers/handleActions.js
@@ -1,0 +1,28 @@
+/**
+* Copyright 2018, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+/**
+ * Creates a reducer based on a handler object.
+ * Example:
+ * ```
+ *  const sequences = handleActions({
+ *    [types.SEQUENCES_UPDATE]: calculateSequencesState,
+ *  }, []);
+ * ```
+ *
+ * Similar to handleActions from redux-actions or createReduce from redux-act
+ */
+export default function handleActions(handlers, initialState) {
+  return function reducer(state = initialState, {type, payload}) {
+    if (handlers.hasOwnProperty(type)) {
+      return handlers[type](state, payload);
+    } else {
+      return state;
+    }
+  };
+}


### PR DESCRIPTION
There are a few properties like e.g.  `currentViewSequence` (the first sequence in the main viewpoint) which are currently computed in the `SequenceViewer`, but are also needed in other views.
At the moment each view computes these values on itself, which is slow and leads to poor decoupling between the views. The views should be as dumb as possible.

A next step might be to use [reselect](https://github.com/reduxjs/reselect) for even better memoization or `react-action` for less boileplate code.