### PR TITLE
Allow to set only {x,y}Pos or {x,y}Movement in {move,update}Position

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "babel-jest": "^23.6.0",
     "babel-plugin-lodash": "^3.3.4",
     "canvas": "^2.0.1",
+    "immutable": "^3.8.2",
     "jest-canvas-mock": "^1.1.0",
     "react": "16.4.2",
     "react-addons-shallow-compare": "^15.6.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -30,6 +30,7 @@ export default {
     replace({
       'process.env.NODE_ENV': JSON.stringify('production'),
       'MSA_DEVELOPMENT_VERSION': version,
+      "const assert = require('assert')": "const assert = {}",
     }),
     babel({
       exclude: 'node_modules/**',
@@ -37,7 +38,7 @@ export default {
     strip({
       debugger: true,
       // defaults to `[ 'console.*', 'assert.*' ]`
-      functions: [ 'console.log', 'assert.*', 'debug', 'alert' ],
+      functions: [ 'console.log', 'assert', 'assert.*', 'debug', 'alert' ],
     }),
     resolve({
       browser: true,

--- a/src/assert.js
+++ b/src/assert.js
@@ -1,0 +1,2 @@
+const assert = require('assert');
+export default assert;

--- a/src/store/positionReducers.js
+++ b/src/store/positionReducers.js
@@ -52,14 +52,20 @@ function commonPositionReducer(prevState, pos) {
  * Reducer for the {move,update}Position events
  */
 const relativePositionReducer = (prevState = {position: {xPos: 0, yPos: 0}}, action) => {
+  const pos = prevState.position;
   switch (action.type) {
     case movePosition.key:
-      const pos = prevState.position;
-      pos.xPos += action.payload.xMovement;
-      pos.yPos += action.payload.yMovement;
-      return commonPositionReducer(prevState, pos);
+      const movePayload = {
+        xPos: pos.xPos + (action.payload.xMovement || 0),
+        yPos: pos.yPos + (action.payload.yMovement || 0),
+      }
+      return commonPositionReducer(prevState, movePayload);
     case updatePosition.key:
-      return commonPositionReducer(prevState, action.payload);
+      const updatePayload = {
+        xPos: action.payload.xPos || pos.xPos,
+        yPos: action.payload.yPos || pos.yPos,
+      };
+      return commonPositionReducer(prevState, updatePayload);
     default:
       return prevState;
   }

--- a/src/store/positionReducers.js
+++ b/src/store/positionReducers.js
@@ -20,6 +20,8 @@ import {
   clamp,
 } from 'lodash-es';
 
+import assert from '../assert';
+
 // send when the main store changes
 export const updateMainStore = createAction("MAINSTORE_UPDATE");
 // move the position relatively by {xMovement, yMovement}
@@ -55,12 +57,18 @@ const relativePositionReducer = (prevState = {position: {xPos: 0, yPos: 0}}, act
   const pos = prevState.position;
   switch (action.type) {
     case movePosition.key:
+      assert(action.payload.xMovement !== undefined ||
+        action.payload.yMovement !== undefined, "must contain at least xMovement" +
+        " or yMovement");
       const movePayload = {
         xPos: pos.xPos + (action.payload.xMovement || 0),
         yPos: pos.yPos + (action.payload.yMovement || 0),
       }
       return commonPositionReducer(prevState, movePayload);
     case updatePosition.key:
+      assert(action.payload.xPos !== undefined ||
+        action.payload.yPos !== undefined, "must contain at least xPos" +
+        " or yPos");
       const updatePayload = {
         xPos: action.payload.xPos || pos.xPos,
         yPos: action.payload.yPos || pos.yPos,

--- a/src/store/positionReducers.test.js
+++ b/src/store/positionReducers.test.js
@@ -1,0 +1,68 @@
+import {
+  actions,
+  createPositionStore,
+  positionReducer,
+} from './positionReducers';
+
+const fakeMainStore = {
+  props: {
+    tileWidth: 50,
+    tileHeight: 50,
+  },
+  sequences: {
+    length: 20,
+    maxLength: 30,
+    raw: {
+      length: 20,
+    }
+  },
+}
+
+describe('positionStore', () => {
+  it('should create actions properly', () => {
+    const payload = {xPos: 10, yPos: 20};
+    expect(actions.updatePosition(payload)).toEqual({
+      type: actions.updatePosition.key,
+      payload: {
+        xPos: 10, yPos: 20,
+      }
+    })
+  })
+
+  it('should should have a valid initial state', () => {
+    const store = createPositionStore(positionReducer);
+    expect(store.getState()).toEqual({
+      position: { xPos: 0, yPos: 0 }
+    });
+  });
+
+  it('should update the position store after an updateMainStore', () => {
+    const store = createPositionStore(positionReducer);
+    store.dispatch(actions.updateMainStore(fakeMainStore));
+    expect(store.getState()).toEqual({
+      position: { xPos: 0, yPos: 0 },
+      ...fakeMainStore,
+      xPosOffset: -0,
+      yPosOffset: -0,
+      currentViewSequence: 0,
+      currentViewSequencePosition: 0
+    });
+  })
+
+  it('should update the position store after an updatePosition', () => {
+    const store = createPositionStore(positionReducer);
+    store.dispatch(actions.updateMainStore(fakeMainStore));
+    store.dispatch(actions.updatePosition({xPos: 20, yPos: 60}));
+    expect(store.getState()).toEqual({
+      ...fakeMainStore,
+     "currentViewSequencePosition" : 0,
+     "xPosOffset" : -0,
+     "position" : {
+        "yPos" : 0,
+        "xPos" : 0
+     },
+     "yPosOffset" : -0,
+     "currentViewSequence" : 0,
+    });
+  })
+})

--- a/src/store/positionReducers.test.js
+++ b/src/store/positionReducers.test.js
@@ -8,6 +8,8 @@ const fakeMainStore = {
   props: {
     tileWidth: 50,
     tileHeight: 50,
+    width: 200,
+    height: 200,
   },
   sequences: {
     length: 20,
@@ -47,6 +49,7 @@ describe('positionStore', () => {
       currentViewSequence: 0,
       currentViewSequencePosition: 0
     });
+    expect(fakeMainStore.position).toBeUndefined();
   })
 
   it('should update the position store after an updatePosition', () => {
@@ -56,12 +59,29 @@ describe('positionStore', () => {
     expect(store.getState()).toEqual({
       ...fakeMainStore,
      "currentViewSequencePosition" : 0,
-     "xPosOffset" : -0,
+     "xPosOffset" : -20,
      "position" : {
-        "yPos" : 0,
-        "xPos" : 0
+        "xPos" : 20,
+        "yPos" : 60,
      },
-     "yPosOffset" : -0,
+     "yPosOffset" : -10,
+     "currentViewSequence" : 0,
+    });
+  })
+
+  it('should update the position store after an movePosition', () => {
+    const store = createPositionStore(positionReducer);
+    store.dispatch(actions.updateMainStore(fakeMainStore));
+    store.dispatch(actions.movePosition({xMovement: 30, yMovement: 40}));
+    expect(store.getState()).toEqual({
+      ...fakeMainStore,
+     "currentViewSequencePosition" : 0,
+     "xPosOffset" : -30,
+     "position" : {
+        "xPos" : 30,
+        "yPos" : 40,
+     },
+     "yPosOffset" : -40,
      "currentViewSequence" : 0,
     });
   })

--- a/src/store/positionReducers.test.js
+++ b/src/store/positionReducers.test.js
@@ -1,10 +1,11 @@
+import { Map } from  'immutable';
 import {
   actions,
   createPositionStore,
   positionReducer,
 } from './positionReducers';
 
-const fakeMainStore = {
+const fakeMainStore = Map({
   props: {
     tileWidth: 50,
     tileHeight: 50,
@@ -18,9 +19,9 @@ const fakeMainStore = {
       length: 20,
     }
   },
-}
+});
 
-describe('positionStore', () => {
+describe('Basic positionStore tests', () => {
   it('should create actions properly', () => {
     const payload = {xPos: 10, yPos: 20};
     expect(actions.updatePosition(payload)).toEqual({
@@ -40,10 +41,10 @@ describe('positionStore', () => {
 
   it('should update the position store after an updateMainStore', () => {
     const store = createPositionStore(positionReducer);
-    store.dispatch(actions.updateMainStore(fakeMainStore));
+    store.dispatch(actions.updateMainStore(fakeMainStore.toObject()));
     expect(store.getState()).toEqual({
       position: { xPos: 0, yPos: 0 },
-      ...fakeMainStore,
+      ...fakeMainStore.toObject(),
       xPosOffset: -0,
       yPosOffset: -0,
       currentViewSequence: 0,
@@ -51,13 +52,18 @@ describe('positionStore', () => {
     });
     expect(fakeMainStore.position).toBeUndefined();
   })
+})
 
+describe('PositionStore tests with an existing mainStore', () => {
+  let store;
+  beforeEach(() => {
+    store = createPositionStore(positionReducer);
+    store.dispatch(actions.updateMainStore(fakeMainStore.toObject()));
+  })
   it('should update the position store after an updatePosition', () => {
-    const store = createPositionStore(positionReducer);
-    store.dispatch(actions.updateMainStore(fakeMainStore));
     store.dispatch(actions.updatePosition({xPos: 20, yPos: 60}));
     expect(store.getState()).toEqual({
-      ...fakeMainStore,
+      ...fakeMainStore.toObject(),
      "currentViewSequencePosition" : 0,
      "xPosOffset" : -20,
      "position" : {
@@ -65,16 +71,14 @@ describe('positionStore', () => {
         "yPos" : 60,
      },
      "yPosOffset" : -10,
-     "currentViewSequence" : 0,
+     "currentViewSequence" : 1,
     });
   })
 
   it('should update the position store after an updatePosition with only xPos', () => {
-    const store = createPositionStore(positionReducer);
-    store.dispatch(actions.updateMainStore(fakeMainStore));
     store.dispatch(actions.updatePosition({xPos: 20}));
     expect(store.getState()).toEqual({
-      ...fakeMainStore,
+      ...fakeMainStore.toObject(),
      "currentViewSequencePosition" : 0,
      "xPosOffset" : -20,
      "position" : {
@@ -87,11 +91,9 @@ describe('positionStore', () => {
   })
 
   it('should update the position store after an updatePosition with only yPos', () => {
-    const store = createPositionStore(positionReducer);
-    store.dispatch(actions.updateMainStore(fakeMainStore));
     store.dispatch(actions.updatePosition({yPos: 60}));
     expect(store.getState()).toEqual({
-      ...fakeMainStore,
+      ...fakeMainStore.toObject(),
      "currentViewSequencePosition" : 0,
      "xPosOffset" : -0,
      "position" : {
@@ -99,17 +101,15 @@ describe('positionStore', () => {
         "yPos" : 60,
      },
      "yPosOffset" : -10,
-     "currentViewSequence" : 0,
+     "currentViewSequence" : 1,
     });
   })
 
   it('should update the position store after multiple updatePosition', () => {
-    const store = createPositionStore(positionReducer);
-    store.dispatch(actions.updateMainStore(fakeMainStore));
     store.dispatch(actions.updatePosition({xPos: 20}));
     store.dispatch(actions.updatePosition({yPos: 60}));
     expect(store.getState()).toEqual({
-      ...fakeMainStore,
+      ...fakeMainStore.toObject(),
      "currentViewSequencePosition" : 0,
      "xPosOffset" : -20,
      "position" : {
@@ -117,16 +117,14 @@ describe('positionStore', () => {
         "yPos" : 60,
      },
      "yPosOffset" : -10,
-     "currentViewSequence" : 0,
+     "currentViewSequence" : 1,
     });
   })
 
   it('should update the position store after an movePosition', () => {
-    const store = createPositionStore(positionReducer);
-    store.dispatch(actions.updateMainStore(fakeMainStore));
     store.dispatch(actions.movePosition({xMovement: 30, yMovement: 40}));
     expect(store.getState()).toEqual({
-      ...fakeMainStore,
+      ...fakeMainStore.toObject(),
      "currentViewSequencePosition" : 0,
      "xPosOffset" : -30,
      "position" : {
@@ -139,11 +137,9 @@ describe('positionStore', () => {
   })
 
   it('should update the position store after an movePosition with only xMovement', () => {
-    const store = createPositionStore(positionReducer);
-    store.dispatch(actions.updateMainStore(fakeMainStore));
     store.dispatch(actions.movePosition({xMovement: 30}));
     expect(store.getState()).toEqual({
-      ...fakeMainStore,
+      ...fakeMainStore.toObject(),
      "currentViewSequencePosition" : 0,
      "xPosOffset" : -30,
      "position" : {
@@ -156,11 +152,9 @@ describe('positionStore', () => {
   })
 
   it('should update the position store after an movePosition with only yMovement', () => {
-    const store = createPositionStore(positionReducer);
-    store.dispatch(actions.updateMainStore(fakeMainStore));
     store.dispatch(actions.movePosition({yMovement: 40}));
     expect(store.getState()).toEqual({
-      ...fakeMainStore,
+      ...fakeMainStore.toObject(),
      "currentViewSequencePosition" : 0,
      "xPosOffset" : -0,
      "position" : {
@@ -173,12 +167,10 @@ describe('positionStore', () => {
   })
 
   it('should update the position store after multiple movePosition', () => {
-    const store = createPositionStore(positionReducer);
-    store.dispatch(actions.updateMainStore(fakeMainStore));
     store.dispatch(actions.movePosition({xMovement: 30, yMovement: 40}));
     store.dispatch(actions.movePosition({xMovement: 50, yMovement: 20}));
     expect(store.getState()).toEqual({
-      ...fakeMainStore,
+      ...fakeMainStore.toObject(),
      "currentViewSequencePosition" : 1,
      "xPosOffset" : -30,
      "position" : {
@@ -186,6 +178,32 @@ describe('positionStore', () => {
         "yPos" : 60,
      },
      "yPosOffset" : -10,
+     "currentViewSequence" : 1,
+    });
+  })
+
+  it('should update the position store after multiple movePosition', () => {
+    const movements = [
+      [0, 1],
+      [1, 0],
+      [1, 2],
+      [1, 1],
+      [1, 0],
+      [0, 1],
+      [0, 0],
+    ];
+    movements.forEach(m => {
+      store.dispatch(actions.movePosition({xMovement: m[0], yMovement: m[1]}));
+    });
+    expect(store.getState()).toEqual({
+      ...fakeMainStore.toObject(),
+     "currentViewSequencePosition" : 0,
+     "xPosOffset" : -4,
+     "position" : {
+        "xPos" : 4,
+        "yPos" : 5,
+     },
+     "yPosOffset" : -5,
      "currentViewSequence" : 0,
     });
   })

--- a/src/store/positionReducers.test.js
+++ b/src/store/positionReducers.test.js
@@ -69,6 +69,58 @@ describe('positionStore', () => {
     });
   })
 
+  it('should update the position store after an updatePosition with only xPos', () => {
+    const store = createPositionStore(positionReducer);
+    store.dispatch(actions.updateMainStore(fakeMainStore));
+    store.dispatch(actions.updatePosition({xPos: 20}));
+    expect(store.getState()).toEqual({
+      ...fakeMainStore,
+     "currentViewSequencePosition" : 0,
+     "xPosOffset" : -20,
+     "position" : {
+        "xPos" : 20,
+        "yPos" : 0,
+     },
+     "yPosOffset" : -0,
+     "currentViewSequence" : 0,
+    });
+  })
+
+  it('should update the position store after an updatePosition with only yPos', () => {
+    const store = createPositionStore(positionReducer);
+    store.dispatch(actions.updateMainStore(fakeMainStore));
+    store.dispatch(actions.updatePosition({yPos: 60}));
+    expect(store.getState()).toEqual({
+      ...fakeMainStore,
+     "currentViewSequencePosition" : 0,
+     "xPosOffset" : -0,
+     "position" : {
+        "xPos" : 0,
+        "yPos" : 60,
+     },
+     "yPosOffset" : -10,
+     "currentViewSequence" : 0,
+    });
+  })
+
+  it('should update the position store after multiple updatePosition', () => {
+    const store = createPositionStore(positionReducer);
+    store.dispatch(actions.updateMainStore(fakeMainStore));
+    store.dispatch(actions.updatePosition({xPos: 20}));
+    store.dispatch(actions.updatePosition({yPos: 60}));
+    expect(store.getState()).toEqual({
+      ...fakeMainStore,
+     "currentViewSequencePosition" : 0,
+     "xPosOffset" : -20,
+     "position" : {
+        "xPos" : 20,
+        "yPos" : 60,
+     },
+     "yPosOffset" : -10,
+     "currentViewSequence" : 0,
+    });
+  })
+
   it('should update the position store after an movePosition', () => {
     const store = createPositionStore(positionReducer);
     store.dispatch(actions.updateMainStore(fakeMainStore));
@@ -82,6 +134,58 @@ describe('positionStore', () => {
         "yPos" : 40,
      },
      "yPosOffset" : -40,
+     "currentViewSequence" : 0,
+    });
+  })
+
+  it('should update the position store after an movePosition with only xMovement', () => {
+    const store = createPositionStore(positionReducer);
+    store.dispatch(actions.updateMainStore(fakeMainStore));
+    store.dispatch(actions.movePosition({xMovement: 30}));
+    expect(store.getState()).toEqual({
+      ...fakeMainStore,
+     "currentViewSequencePosition" : 0,
+     "xPosOffset" : -30,
+     "position" : {
+        "xPos" : 30,
+        "yPos" : 0,
+     },
+     "yPosOffset" : -0,
+     "currentViewSequence" : 0,
+    });
+  })
+
+  it('should update the position store after an movePosition with only yMovement', () => {
+    const store = createPositionStore(positionReducer);
+    store.dispatch(actions.updateMainStore(fakeMainStore));
+    store.dispatch(actions.movePosition({yMovement: 40}));
+    expect(store.getState()).toEqual({
+      ...fakeMainStore,
+     "currentViewSequencePosition" : 0,
+     "xPosOffset" : -0,
+     "position" : {
+        "xPos" : 0,
+        "yPos" : 40,
+     },
+     "yPosOffset" : -40,
+     "currentViewSequence" : 0,
+    });
+  })
+
+  it('should update the position store after multiple movePosition', () => {
+    const store = createPositionStore(positionReducer);
+    store.dispatch(actions.updateMainStore(fakeMainStore));
+    store.dispatch(actions.movePosition({xMovement: 30, yMovement: 40}));
+    store.dispatch(actions.movePosition({xMovement: 50, yMovement: 20}));
+    expect(store.getState()).toEqual({
+      ...fakeMainStore,
+     "currentViewSequencePosition" : 1,
+     "xPosOffset" : -30,
+     "position" : {
+        "xPos" : 80,
+        "yPos" : 60,
+     },
+     "yPosOffset" : -10,
      "currentViewSequence" : 0,
     });
   })

--- a/src/stories/events.js
+++ b/src/stories/events.js
@@ -171,7 +171,7 @@ storiesOf('Events', module)
         this.el.updatePosition({xPos: 100, yPos: 100});
       }
       onGenericClick = (e) => {
-        const action = actions.movePosition({xMovement: 50, yMovement: 50});
+        const action = actions.movePosition({xMovement: 50});
         this.el.dispatch(action);
       }
       render() {


### PR DESCRIPTION
This enables the following:

```
actions.movePosition({xMovement: 50});
actions.updatePosition({xPos: 50});
```