### PR TITLE
Unify Babel configurations

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -7,4 +7,13 @@ module.exports = {
         "@babel/plugin-proposal-object-rest-spread",
         "@babel/plugin-proposal-class-properties",
     ],
+  "env": {
+    "production": {
+        "plugins": [
+            "@babel/plugin-proposal-object-rest-spread",
+            "@babel/plugin-proposal-class-properties",
+            "lodash",
+        ],
+    }
+  }
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,22 +1,10 @@
 module.exports = {
     "presets": [
-        ["@babel/preset-env", {"modules": "commonjs"}],
+        "@babel/preset-env",
         "@babel/preset-react",
     ],
     "plugins": [
         "@babel/plugin-proposal-object-rest-spread",
         "@babel/plugin-proposal-class-properties",
     ],
-    "env": {
-        "test": {
-            "presets": [
-                ["@babel/preset-env", {"modules": "commonjs"}],
-                "@babel/preset-react",
-            ],
-            plugins: [
-                "transform-es2015-modules-commonjs",
-                "dynamic-import-node"
-            ]
-        }
-    }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -32,15 +32,7 @@ export default {
       'MSA_DEVELOPMENT_VERSION': version,
     }),
     babel({
-      babelrc: false,
       exclude: 'node_modules/**',
-      presets: ['@babel/preset-react', '@babel/preset-env'],
-      plugins: [
-        '@babel/plugin-proposal-object-rest-spread',
-        '@babel/plugin-proposal-class-properties',
-        "lodash",
-      ],
-      //externalHelpers: false,
     }),
     strip({
       debugger: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ const config = {
     index: ['./src/lib.js'],
   },
   devtool: 'eval-source-map',
+  mode: "production", // or --mode=development
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: '[name].js',
@@ -37,15 +38,12 @@ const config = {
       test: /\.js$/,
       exclude: /node_modules/,
       loader: 'babel-loader',
-      options: {
-        presets: ['react-app'],
-      },
     }],
   },
+  optimization: {
+    minimize: true,
+  },
   plugins: [
-    new webpack.optimize.UglifyJsPlugin({
-      comments: false,
-    }),
     new webpack.DefinePlugin({
       'process.env': {
         NODE_ENV: JSON.stringify('production'),


### PR DESCRIPTION
- Move babel config from rollup to babel.config.js
- Upgrade webpack config to Webpack4
- Use production config in babel for all projects