### PR TITLE
Add multiple layout algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,285 @@ When children are passed it acts as a Context Provider for the msaStore,
 otherwise it provides a default layout and forwards it props the respective
 components.
 
-TBD
+#### Props
+
+##### `barAttributes`
+
+Attributes to apply to each bar.
+
+type: `object`
+
+
+##### `barFillColor`
+
+Fill color of the OverviewBar, e.g. `#999999`
+
+type: `string`
+
+
+##### `barMethod`
+
+Method to use for the OverviewBar:
+ - `information-content`: Information entropy after Shannon of a column (scaled)
+ - `conservation`: Conservation of a column (scaled)
+
+type: `enum('information-content'|'conservation')`
+
+
+##### `barStyle`
+
+Inline styles to apply to each bar.
+
+type: `object`
+
+
+##### `colorScheme`
+
+Colorscheme to use. Currently the follow colorschemes are supported:
+`buried_index`, `clustal`, `clustal2`, `cinema`, `helix_propensity`, `hydro`,
+`lesk`, `mae`, `nucleotide`, `purine_pyrimidine`, `strand_propensity`, `taylor`,
+`turn_propensity`, and `zappo`.
+
+See [msa-colorschemes](https://github.com/wilzbach/msa-colorschemes) for details.
+
+type: `custom`
+
+
+##### `height`
+
+Height of the sequence viewer (in pixels), e.g. `500`.
+
+type: `number`
+
+
+##### `labelAttributes`
+
+Attributes to apply to each label.
+
+type: `object`
+
+
+##### `labelComponent`
+
+Component to create labels from.
+
+type: `union(object|func)`
+
+
+##### `labelStyle`
+
+Inline styles to apply to each label.
+
+type: `object`
+
+
+##### `layout`
+
+Predefined layout scheme to use (only used when no child elements are provided).
+Available layouts: `basic`, `inverse`, `full`, `compact`, `funky`
+
+type: `enum('basic'|'default'|'inverse'|'full'|'compact'|'funky')`
+
+
+##### `markerAttributes`
+
+Attributes to apply to each marker.
+
+type: `object`
+
+
+##### `markerComponent`
+
+Component to create markers from.
+
+type: `union(object|func)`
+
+
+##### `markerStartIndex`
+
+At which number the PositionBar marker should start counting.
+Typical values are: `1` (1-based indexing) and `0` (0-based indexing).
+
+type: `number`
+
+
+##### `markerSteps`
+
+At which steps the position labels should appear, e.g. `2` for (1, 3, 5)
+
+type: `number`
+
+
+##### `markerStyle`
+
+Inline styles to apply to each marker.
+
+type: `object`
+
+
+##### `msaStore`
+
+A custom msaStore (created with `createMSAStore`).
+Useful for custom interaction with other components
+
+type: `object`
+
+
+##### `onResidueClick`
+
+Callback fired when the mouse pointer clicked a residue.
+
+type: `func`
+
+
+##### `onResidueDoubleClick`
+
+Callback fired when the mouse pointer clicked a residue.
+
+type: `func`
+
+
+##### `onResidueMouseEnter`
+
+Callback fired when the mouse pointer is entering a residue.
+
+type: `func`
+
+
+##### `onResidueMouseLeave`
+
+Callback fired when the mouse pointer is leaving a residue.
+
+type: `func`
+
+
+##### `position`
+
+Current x and y position of the viewpoint
+in the main sequence viewer (in pixels).
+This specifies the position of the top-left corner
+of the viewpoint within the entire alignment,
+e.g. `{xPos: 20, yPos: 5}`.
+
+type: `custom`
+
+
+##### `sequenceBorder`
+
+Whether to draw a border.
+
+type: `bool`
+
+
+##### `sequenceBorderColor`
+
+Color of the border. Name, hex or RGB value.
+
+type: `string`
+
+
+##### `sequenceBorderWidth`
+
+Width of the border.
+
+type: `number`
+
+
+##### `sequenceOverflow`
+
+What should happen if content overflows.
+
+type: `enum("hidden"|"auto"|"scroll")`
+
+
+##### `sequenceOverflowX`
+
+What should happen if x-axis content overflows (overwrites "overflow")
+
+type: `enum("hidden"|"auto"|"scroll"|"initial")`
+
+
+##### `sequenceOverflowY`
+
+What should happen if y-axis content overflows (overwrites "overflow")
+
+type: `enum("hidden"|"auto"|"scroll"|"initial")`
+
+
+##### `sequenceScrollBarPositionX`
+
+X Position of the scroll bar ("top or "bottom")
+
+type: `enum("top"|"bottom")`
+
+
+##### `sequenceScrollBarPositionY`
+
+Y Position of the scroll bar ("left" or "right")
+
+type: `enum("left"|"right")`
+
+
+##### `sequenceTextColor`
+
+Color of the text residue letters (name, hex or RGB value)
+
+type: `string`
+
+
+##### `sequenceTextFont`
+
+Font to use when drawing the individual residues.
+
+type: `string`
+
+
+##### `sequences` (required)
+
+Sequence data.
+`sequences` expects an array of individual sequences.
+
+`sequence`: Raw sequence, e.g. `MEEPQSDPSIEP` (required)
+`name`: name of the sequence, e.g. `Sequence X`
+
+Example:
+
+```js
+const sequences = [
+  {
+    name: "seq.1",
+    sequence: "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+  },
+  {
+    name: "seq.2",
+    sequence: "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+  },
+];
+```
+
+type: `arrayOf[object Object]`
+
+
+##### `tileHeight`
+
+Height of the main tiles (in pixels), e.g. `20`
+
+type: `number`
+
+
+##### `tileWidth`
+
+Width of the main tiles (in pixels), e.g. `20`
+
+type: `number`
+
+
+##### `width`
+
+Width of the sequence viewer (in pixels), e.g. `500`.
+
+type: `number`
+
 ### `Labels` (component)
 
 Displays the sequence names.

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ const sequences = [
 ];
 ```
 
-type: `arrayOf[object Object]`
+type: `arrayOf[SequencePropType]`
 
 
 ##### `tileHeight`

--- a/docs/MSAViewer.md
+++ b/docs/MSAViewer.md
@@ -262,7 +262,7 @@ const sequences = [
 ];
 ```
 
-type: `arrayOf[object Object]`
+type: `arrayOf[SequencePropType]`
 
 
 ### `tileHeight`

--- a/docs/MSAViewer.md
+++ b/docs/MSAViewer.md
@@ -6,4 +6,282 @@ When children are passed it acts as a Context Provider for the msaStore,
 otherwise it provides a default layout and forwards it props the respective
 components.
 
-TBD
+## Props
+
+### `barAttributes`
+
+Attributes to apply to each bar.
+
+type: `object`
+
+
+### `barFillColor`
+
+Fill color of the OverviewBar, e.g. `#999999`
+
+type: `string`
+
+
+### `barMethod`
+
+Method to use for the OverviewBar:
+ - `information-content`: Information entropy after Shannon of a column (scaled)
+ - `conservation`: Conservation of a column (scaled)
+
+type: `enum('information-content'|'conservation')`
+
+
+### `barStyle`
+
+Inline styles to apply to each bar.
+
+type: `object`
+
+
+### `colorScheme`
+
+Colorscheme to use. Currently the follow colorschemes are supported:
+`buried_index`, `clustal`, `clustal2`, `cinema`, `helix_propensity`, `hydro`,
+`lesk`, `mae`, `nucleotide`, `purine_pyrimidine`, `strand_propensity`, `taylor`,
+`turn_propensity`, and `zappo`.
+
+See [msa-colorschemes](https://github.com/wilzbach/msa-colorschemes) for details.
+
+type: `custom`
+
+
+### `height`
+
+Height of the sequence viewer (in pixels), e.g. `500`.
+
+type: `number`
+
+
+### `labelAttributes`
+
+Attributes to apply to each label.
+
+type: `object`
+
+
+### `labelComponent`
+
+Component to create labels from.
+
+type: `union(object|func)`
+
+
+### `labelStyle`
+
+Inline styles to apply to each label.
+
+type: `object`
+
+
+### `layout`
+
+Predefined layout scheme to use (only used when no child elements are provided).
+Available layouts: `basic`, `inverse`, `full`, `compact`, `funky`
+
+type: `enum('basic'|'default'|'inverse'|'full'|'compact'|'funky')`
+
+
+### `markerAttributes`
+
+Attributes to apply to each marker.
+
+type: `object`
+
+
+### `markerComponent`
+
+Component to create markers from.
+
+type: `union(object|func)`
+
+
+### `markerStartIndex`
+
+At which number the PositionBar marker should start counting.
+Typical values are: `1` (1-based indexing) and `0` (0-based indexing).
+
+type: `number`
+
+
+### `markerSteps`
+
+At which steps the position labels should appear, e.g. `2` for (1, 3, 5)
+
+type: `number`
+
+
+### `markerStyle`
+
+Inline styles to apply to each marker.
+
+type: `object`
+
+
+### `msaStore`
+
+A custom msaStore (created with `createMSAStore`).
+Useful for custom interaction with other components
+
+type: `object`
+
+
+### `onResidueClick`
+
+Callback fired when the mouse pointer clicked a residue.
+
+type: `func`
+
+
+### `onResidueDoubleClick`
+
+Callback fired when the mouse pointer clicked a residue.
+
+type: `func`
+
+
+### `onResidueMouseEnter`
+
+Callback fired when the mouse pointer is entering a residue.
+
+type: `func`
+
+
+### `onResidueMouseLeave`
+
+Callback fired when the mouse pointer is leaving a residue.
+
+type: `func`
+
+
+### `position`
+
+Current x and y position of the viewpoint
+in the main sequence viewer (in pixels).
+This specifies the position of the top-left corner
+of the viewpoint within the entire alignment,
+e.g. `{xPos: 20, yPos: 5}`.
+
+type: `custom`
+
+
+### `sequenceBorder`
+
+Whether to draw a border.
+
+type: `bool`
+
+
+### `sequenceBorderColor`
+
+Color of the border. Name, hex or RGB value.
+
+type: `string`
+
+
+### `sequenceBorderWidth`
+
+Width of the border.
+
+type: `number`
+
+
+### `sequenceOverflow`
+
+What should happen if content overflows.
+
+type: `enum("hidden"|"auto"|"scroll")`
+
+
+### `sequenceOverflowX`
+
+What should happen if x-axis content overflows (overwrites "overflow")
+
+type: `enum("hidden"|"auto"|"scroll"|"initial")`
+
+
+### `sequenceOverflowY`
+
+What should happen if y-axis content overflows (overwrites "overflow")
+
+type: `enum("hidden"|"auto"|"scroll"|"initial")`
+
+
+### `sequenceScrollBarPositionX`
+
+X Position of the scroll bar ("top or "bottom")
+
+type: `enum("top"|"bottom")`
+
+
+### `sequenceScrollBarPositionY`
+
+Y Position of the scroll bar ("left" or "right")
+
+type: `enum("left"|"right")`
+
+
+### `sequenceTextColor`
+
+Color of the text residue letters (name, hex or RGB value)
+
+type: `string`
+
+
+### `sequenceTextFont`
+
+Font to use when drawing the individual residues.
+
+type: `string`
+
+
+### `sequences` (required)
+
+Sequence data.
+`sequences` expects an array of individual sequences.
+
+`sequence`: Raw sequence, e.g. `MEEPQSDPSIEP` (required)
+`name`: name of the sequence, e.g. `Sequence X`
+
+Example:
+
+```js
+const sequences = [
+  {
+    name: "seq.1",
+    sequence: "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+  },
+  {
+    name: "seq.2",
+    sequence: "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+  },
+];
+```
+
+type: `arrayOf[object Object]`
+
+
+### `tileHeight`
+
+Height of the main tiles (in pixels), e.g. `20`
+
+type: `number`
+
+
+### `tileWidth`
+
+Width of the main tiles (in pixels), e.g. `20`
+
+type: `number`
+
+
+### `width`
+
+Width of the sequence viewer (in pixels), e.g. `500`.
+
+type: `number`
+

--- a/docs/generateMarkdown.js
+++ b/docs/generateMarkdown.js
@@ -38,7 +38,14 @@ function generatePropType(type) {
         .join('|') +
       ')';
   } else {
-    values = type.value;
+    if (type.value && type.value.name === 'custom') {
+      values = type.value.raw;
+      if (type.name === 'arrayOf') {
+        values = `[${values}]`;
+      }
+    } else {
+      values = type.value;
+    }
   }
 
   return 'type: `' + type.name + (values ? values : '') + '`\n';

--- a/src/PropTypes.js
+++ b/src/PropTypes.js
@@ -47,6 +47,10 @@ export const PositionPropType = PropTypes.shape({
   yPos: PropTypes.number,
 })
 
+/**
+ * These are the "globally" exposes properties which get inserted into the
+ * Redux store.
+ */
 export const MSAPropTypes = {
   /**
    * Width of the sequence viewer (in pixels), e.g. `500`.
@@ -88,5 +92,3 @@ export const msaDefaultProps = {
   tileHeight: 20,
   colorScheme: "clustal",
 };
-
-export {PropTypes};

--- a/src/PropTypes.js
+++ b/src/PropTypes.js
@@ -148,8 +148,9 @@ export const MSAPropTypes = {
 
   /**
    * Predefined layout scheme to use (only used when no child elements are provided).
+   * Available layouts: `basic`, `inverse`
    */
-  layout: PropTypes.oneOf(['basic', 'default']),
+  layout: PropTypes.oneOf(['basic', 'default', 'inverse']),
 };
 
 

--- a/src/PropTypes.js
+++ b/src/PropTypes.js
@@ -148,9 +148,9 @@ export const MSAPropTypes = {
 
   /**
    * Predefined layout scheme to use (only used when no child elements are provided).
-   * Available layouts: `basic`, `inverse`
+   * Available layouts: `basic`, `inverse`, `full`
    */
-  layout: PropTypes.oneOf(['basic', 'default', 'inverse']),
+  layout: PropTypes.oneOf(['basic', 'default', 'inverse', 'full']),
 };
 
 

--- a/src/PropTypes.js
+++ b/src/PropTypes.js
@@ -148,9 +148,10 @@ export const MSAPropTypes = {
 
   /**
    * Predefined layout scheme to use (only used when no child elements are provided).
-   * Available layouts: `basic`, `inverse`, `full`, `compact`
+   * Available layouts: `basic`, `inverse`, `full`, `compact`, `funky`
    */
-  layout: PropTypes.oneOf(['basic', 'default', 'inverse', 'full', 'compact']),
+  layout: PropTypes.oneOf(['basic', 'default', 'inverse', 'full', 'compact',
+    'funky']),
 };
 
 

--- a/src/PropTypes.js
+++ b/src/PropTypes.js
@@ -145,6 +145,11 @@ export const MSAPropTypes = {
    * Callback fired when the mouse pointer clicked a residue.
    */
   onResidueDoubleClick: PropTypes.func,
+
+  /**
+   * Predefined layout scheme to use (only used when no child elements are provided).
+   */
+  layout: PropTypes.oneOf(['basic', 'default']),
 };
 
 

--- a/src/PropTypes.js
+++ b/src/PropTypes.js
@@ -148,9 +148,9 @@ export const MSAPropTypes = {
 
   /**
    * Predefined layout scheme to use (only used when no child elements are provided).
-   * Available layouts: `basic`, `inverse`, `full`
+   * Available layouts: `basic`, `inverse`, `full`, `compact`
    */
-  layout: PropTypes.oneOf(['basic', 'default', 'inverse', 'full']),
+  layout: PropTypes.oneOf(['basic', 'default', 'inverse', 'full', 'compact']),
 };
 
 

--- a/src/PropTypes.js
+++ b/src/PropTypes.js
@@ -49,30 +49,6 @@ export const PositionPropType = PropTypes.shape({
 
 export const MSAPropTypes = {
   /**
-   * Sequence data.
-   * `sequences` expects an array of individual sequences.
-   *
-   * `sequence`: Raw sequence, e.g. `MEEPQSDPSIEP` (required)
-   * `name`: name of the sequence, e.g. `Sequence X`
-   *
-   * Example:
-   *
-   * ```js
-   * const sequences = [
-   *   {
-   *     name: "seq.1",
-   *     sequence: "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-   *   },
-   *   {
-   *     name: "seq.2",
-   *     sequence: "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-   *   },
-   * ];
-   * ```
-   */
-  sequences: PropTypes.arrayOf(SequencePropType).isRequired,
-
-  /**
    * Width of the sequence viewer (in pixels), e.g. `500`.
    */
   width: PropTypes.number,
@@ -93,20 +69,6 @@ export const MSAPropTypes = {
   tileHeight: PropTypes.number,
 
   /**
-   * Font of the individual residue tiles, e.g. `"20px Arial"`.
-   */
-  textFont: PropTypes.string,
-
-  /**
-   * Current x and y position of the viewpoint
-   * in the main sequence viewer (in pixels).
-   * This specifies the position of the top-left corner
-   * of the viewpoint within the entire alignment,
-   * e.g. `{xPos: 20, yPos: 5}`.
-   */
-  position: PositionPropType,
-
-  /**
    * Colorscheme to use. Currently the follow colorschemes are supported:
    * `buried_index`, `clustal`, `clustal2`, `cinema`, `helix_propensity`, `hydro`,
    *`lesk`, `mae`, `nucleotide`, `purine_pyrimidine`, `strand_propensity`, `taylor`,
@@ -115,43 +77,6 @@ export const MSAPropTypes = {
   * See [msa-colorschemes](https://github.com/wilzbach/msa-colorschemes) for details.
   */
   colorScheme: ColorSchemePropType,
-
-  /**
-   * Background color to use, e.g. `red`
-   */
-  backgroundColor: PropTypes.string,
-
-  /**
-   * Rendering engine: `canvas` or `webgl` (experimental).
-   */
-  engine: PropTypes.oneOf(['canvas', 'webl']), // experimental
-
-  /**
-   * Callback fired when the mouse pointer is entering a residue.
-   */
-  onResidueMouseEnter: PropTypes.func,
-
-  /**
-   * Callback fired when the mouse pointer is leaving a residue.
-   */
-  onResidueMouseLeave: PropTypes.func,
-
-  /**
-   * Callback fired when the mouse pointer clicked a residue.
-   */
-  onResidueClick: PropTypes.func,
-
-  /**
-   * Callback fired when the mouse pointer clicked a residue.
-   */
-  onResidueDoubleClick: PropTypes.func,
-
-  /**
-   * Predefined layout scheme to use (only used when no child elements are provided).
-   * Available layouts: `basic`, `inverse`, `full`, `compact`, `funky`
-   */
-  layout: PropTypes.oneOf(['basic', 'default', 'inverse', 'full', 'compact',
-    'funky']),
 };
 
 
@@ -162,8 +87,6 @@ export const msaDefaultProps = {
   tileWidth: 20,
   tileHeight: 20,
   colorScheme: "clustal",
-  backgroundColor: "red",
-  engine: "canvas", // experimental
 };
 
 export {PropTypes};

--- a/src/components/Canvas/__snapshots__/SequenceViewer.test.js.snap
+++ b/src/components/Canvas/__snapshots__/SequenceViewer.test.js.snap
@@ -1116,9 +1116,7 @@ exports[`renders invalidates the tile cache changed properties shouldn't invalid
 
 exports[`renders without crashing 1`] = `
 <PropsToReduxComponent
-  backgroundColor="red"
   colorScheme="clustal"
-  engine="canvas"
   height={100}
   sequences={
     Array [
@@ -1802,9 +1800,7 @@ exports[`sends movement actions on mousemove events should change the cursor sta
 
 exports[`should fire an event on mouseclick 1`] = `
 <PropsToReduxComponent
-  backgroundColor="red"
   colorScheme="clustal"
-  engine="canvas"
   height={200}
   sequences={
     Array [

--- a/src/components/MSAViewer.js
+++ b/src/components/MSAViewer.js
@@ -9,6 +9,8 @@
 import React, { Component } from 'react';
 import createRef from 'create-react-ref/lib/createRef';
 
+import PropTypes from 'prop-types';
+
 import {
   forOwn,
   memoize,
@@ -21,7 +23,6 @@ import {
   ColorSchemePropType,
   PositionPropType,
   MSAPropTypes,
-  PropTypes,
 } from '../PropTypes';
 
 import MSAProvider from '../store/provider';
@@ -140,16 +141,7 @@ MSAViewerComponent.childContextTypes = {
   positionMSAStore: PropTypes.object,
 };
 
-const MSAViewer = propsToRedux(MSAViewerComponent);
-
-MSAViewer.defaultProps = msaDefaultProps;
-MSAViewer.propTypes = {
-  /**
-   * A custom msaStore (created with `createMSAStore`).
-   * Useful for custom interaction with other components
-   */
-  msaStore: PropTypes.object,
-
+MSAViewerComponent.propTypes = {
   /**
    * Sequence data.
    * `sequences` expects an array of individual sequences.
@@ -195,11 +187,6 @@ MSAViewer.propTypes = {
   tileHeight: PropTypes.number,
 
   /**
-   * Font of the individual residue tiles, e.g. `"20px Arial"`.
-   */
-  textFont: PropTypes.string,
-
-  /**
    * Current x and y position of the viewpoint
    * in the main sequence viewer (in pixels).
    * This specifies the position of the top-left corner
@@ -217,16 +204,6 @@ MSAViewer.propTypes = {
   * See [msa-colorschemes](https://github.com/wilzbach/msa-colorschemes) for details.
   */
   colorScheme: ColorSchemePropType,
-
-  /**
-   * Background color to use, e.g. `red`
-   */
-  backgroundColor: PropTypes.string,
-
-  /**
-   * Rendering engine: `canvas` or `webgl` (experimental).
-   */
-  engine: PropTypes.oneOf(['canvas', 'webl']), // experimental
 
   /**
    * Callback fired when the mouse pointer is entering a residue.
@@ -254,6 +231,143 @@ MSAViewer.propTypes = {
    */
   layout: PropTypes.oneOf(['basic', 'default', 'inverse', 'full', 'compact',
     'funky']),
+
+  /**
+   * Whether to draw a border.
+   */
+  sequenceBorder: PropTypes.bool,
+
+  /**
+   * Color of the border. Name, hex or RGB value.
+   */
+  sequenceBorderColor: PropTypes.string,
+
+  /**
+   * Width of the border.
+   */
+  sequenceBorderWidth: PropTypes.number,
+
+  /**
+   * Color of the text residue letters (name, hex or RGB value)
+   */
+  sequenceTextColor: PropTypes.string,
+
+  /**
+   * Font to use when drawing the individual residues.
+   */
+  sequenceTextFont: PropTypes.string,
+
+  /**
+   * What should happen if content overflows.
+   */
+  sequenceOverflow: PropTypes.oneOf(["hidden", "auto", "scroll"]),
+
+  /**
+   * What should happen if x-axis content overflows (overwrites "overflow")
+   */
+  sequenceOverflowX: PropTypes.oneOf(["hidden", "auto", "scroll", "initial"]),
+
+  /**
+   * What should happen if y-axis content overflows (overwrites "overflow")
+   */
+  sequenceOverflowY: PropTypes.oneOf(["hidden", "auto", "scroll", "initial"]),
+
+  /**
+   * X Position of the scroll bar ("top or "bottom")
+   */
+  sequenceScrollBarPositionX: PropTypes.oneOf(["top", "bottom"]),
+
+  /**
+   * Y Position of the scroll bar ("left" or "right")
+   */
+  sequenceScrollBarPositionY: PropTypes.oneOf(["left", "right"]),
+
+  /**
+   * Component to create labels from.
+   */
+  labelComponent: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+
+  /**
+   * Inline styles to apply to each label.
+   */
+  labelStyle: PropTypes.object,
+
+  /**
+   * Attributes to apply to each label.
+   */
+  labelAttributes: PropTypes.object,
+
+  /**
+   * At which steps the position labels should appear, e.g. `2` for (1, 3, 5)
+   */
+  markerSteps: PropTypes.number,
+
+  /**
+   * At which number the PositionBar marker should start counting.
+   * Typical values are: `1` (1-based indexing) and `0` (0-based indexing).
+   */
+  markerStartIndex: PropTypes.number,
+
+  /**
+   * Component to create markers from.
+   */
+  markerComponent: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+
+  /**
+   * Inline styles to apply to each marker.
+   */
+  markerStyle: PropTypes.object,
+
+  /**
+   * Attributes to apply to each marker.
+   */
+  markerAttributes: PropTypes.object,
+
+  /**
+   * Method to use for the OverviewBar:
+   *  - `information-content`: Information entropy after Shannon of a column (scaled)
+   *  - `conservation`: Conservation of a column (scaled)
+   */
+  barMethod: PropTypes.oneOf(['information-content', 'conservation']),
+
+  /**
+   * Fill color of the OverviewBar, e.g. `#999999`
+   */
+  barFillColor: PropTypes.string,
+
+  /**
+   * Inline styles to apply to each bar.
+   */
+  barStyle: PropTypes.object,
+
+  /**
+   * Attributes to apply to each bar.
+   */
+  barAttributes: PropTypes.object,
+
+  /**
+   * A custom msaStore (created with `createMSAStore`).
+   * Useful for custom interaction with other components
+   */
+  msaStore: PropTypes.object,
 };
+
+const MSAViewer = propsToRedux(MSAViewerComponent);
+MSAViewer.defaultProps = msaDefaultProps;
+
+/**
+ * react-docgen trickery:
+ * React-docgen doesn't detect the MSAViewer as a documented component, because
+ * it only looks for two patterns and MSAViewer is a `propsToRedux`.
+ *
+ * So instead of declaring the properties directly on the MSAViewer,
+ * we declare them on MSAViewerComponent, s.t. they get documented
+ * However, we need to exclude the properties that `propsToRedux` passes to redux.
+ * Luckily, react-docgen doesn't stops looking at the source tree once it found the first `<class>.propTypes` pattern.
+ */
+MSAViewer.propTypes = {...MSAViewerComponent.propTypes};
+MSAViewerComponent.propTypes = omit(MSAViewerComponent.propTypes, [
+  ...Object.keys(MSAPropTypes), 'sequences', 'position',
+]);
 
 export default MSAViewer;

--- a/src/components/MSAViewer.js
+++ b/src/components/MSAViewer.js
@@ -17,6 +17,9 @@ import {
 
 import {
   msaDefaultProps,
+  SequencePropType,
+  ColorSchemePropType,
+  PositionPropType,
   MSAPropTypes,
   PropTypes,
 } from '../PropTypes';
@@ -147,7 +150,110 @@ MSAViewer.propTypes = {
    */
   msaStore: PropTypes.object,
 
-  ...MSAPropTypes
+  /**
+   * Sequence data.
+   * `sequences` expects an array of individual sequences.
+   *
+   * `sequence`: Raw sequence, e.g. `MEEPQSDPSIEP` (required)
+   * `name`: name of the sequence, e.g. `Sequence X`
+   *
+   * Example:
+   *
+   * ```js
+   * const sequences = [
+   *   {
+   *     name: "seq.1",
+   *     sequence: "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+   *   },
+   *   {
+   *     name: "seq.2",
+   *     sequence: "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+   *   },
+   * ];
+   * ```
+   */
+  sequences: PropTypes.arrayOf(SequencePropType).isRequired,
+
+  /**
+   * Width of the sequence viewer (in pixels), e.g. `500`.
+   */
+  width: PropTypes.number,
+
+  /**
+   * Height of the sequence viewer (in pixels), e.g. `500`.
+   */
+  height: PropTypes.number,
+
+  /**
+   * Width of the main tiles (in pixels), e.g. `20`
+   */
+  tileWidth: PropTypes.number,
+
+  /**
+   * Height of the main tiles (in pixels), e.g. `20`
+   */
+  tileHeight: PropTypes.number,
+
+  /**
+   * Font of the individual residue tiles, e.g. `"20px Arial"`.
+   */
+  textFont: PropTypes.string,
+
+  /**
+   * Current x and y position of the viewpoint
+   * in the main sequence viewer (in pixels).
+   * This specifies the position of the top-left corner
+   * of the viewpoint within the entire alignment,
+   * e.g. `{xPos: 20, yPos: 5}`.
+   */
+  position: PositionPropType,
+
+  /**
+   * Colorscheme to use. Currently the follow colorschemes are supported:
+   * `buried_index`, `clustal`, `clustal2`, `cinema`, `helix_propensity`, `hydro`,
+   *`lesk`, `mae`, `nucleotide`, `purine_pyrimidine`, `strand_propensity`, `taylor`,
+   * `turn_propensity`, and `zappo`.
+   *
+  * See [msa-colorschemes](https://github.com/wilzbach/msa-colorschemes) for details.
+  */
+  colorScheme: ColorSchemePropType,
+
+  /**
+   * Background color to use, e.g. `red`
+   */
+  backgroundColor: PropTypes.string,
+
+  /**
+   * Rendering engine: `canvas` or `webgl` (experimental).
+   */
+  engine: PropTypes.oneOf(['canvas', 'webl']), // experimental
+
+  /**
+   * Callback fired when the mouse pointer is entering a residue.
+   */
+  onResidueMouseEnter: PropTypes.func,
+
+  /**
+   * Callback fired when the mouse pointer is leaving a residue.
+   */
+  onResidueMouseLeave: PropTypes.func,
+
+  /**
+   * Callback fired when the mouse pointer clicked a residue.
+   */
+  onResidueClick: PropTypes.func,
+
+  /**
+   * Callback fired when the mouse pointer clicked a residue.
+   */
+  onResidueDoubleClick: PropTypes.func,
+
+  /**
+   * Predefined layout scheme to use (only used when no child elements are provided).
+   * Available layouts: `basic`, `inverse`, `full`, `compact`, `funky`
+   */
+  layout: PropTypes.oneOf(['basic', 'default', 'inverse', 'full', 'compact',
+    'funky']),
 };
 
 export default MSAViewer;

--- a/src/components/MSAViewer.js
+++ b/src/components/MSAViewer.js
@@ -56,10 +56,10 @@ class MSAViewerComponent extends Component {
       super(props);
       this.el = createRef();
       this._setupStores();
-      this.createDomHandler = memoize(this.createDomHandler);
+      this.createDomHandler = memoize(this.createDomHandler.bind(this));
       this.forwardProps = shallowSelect(
         p => omit(p, ['msaStore']),
-        this.forwardProps,
+        this.forwardProps.bind(this),
       );
     }
 
@@ -106,9 +106,9 @@ class MSAViewerComponent extends Component {
      * Inject default event handler if no handler for the respective
      * event has been provided.
      */
-    forOwn(options, (forwardedName, currentName) => {
-      if (!(currentName in defaultEvents)) {
-        options[currentName] = this.createDomHandler(defaultEvents[currentName]);
+    forOwn(defaultEvents, (forwardedName, currentName) => {
+      if (currentName in defaultEvents && !(currentName in options)) {
+        options[currentName] = this.createDomHandler(forwardedName);
       }
     });
     return options;

--- a/src/components/__snapshots__/MSAViewer.test.js.snap
+++ b/src/components/__snapshots__/MSAViewer.test.js.snap
@@ -64,2489 +64,2517 @@ exports[`it should rerender when new props are given 1`] = `
         }
       }
     >
-      <div
-        style={
-          Object {
-            "display": "flex",
-          }
-        }
-      >
-        <Connect(HTMLLabelsComponent)
-          style={
-            Object {
-              "paddingTop": 70,
-            }
-          }
+      <div>
+        <MSALayouter
+          layout="default"
         >
-          <HTMLLabelsComponent
-            cacheElements={10}
-            dispatch={[Function]}
-            height={100}
-            labelStyle={Object {}}
-            nrYTiles={6}
-            sequences={
-              Array [
-                Object {
-                  "name": "sequence 1",
-                  "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                },
-                Object {
-                  "name": "sequence 2",
-                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                },
-                Object {
-                  "name": "sequence 3",
-                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                },
-                Object {
-                  "name": "sequence 4",
-                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                },
-                Object {
-                  "name": "sequence 5",
-                  "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                },
-                Object {
-                  "name": "sequence 6",
-                  "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                },
-                Object {
-                  "name": "sequence 7",
-                  "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                },
-              ]
-            }
-            style={
-              Object {
-                "paddingTop": 70,
-              }
-            }
-            tileHeight={20}
-          >
-            <withPosition(YBarComponent)
-              cacheElements={10}
-              componentCache={[Function]}
-              height={100}
-              nrYTiles={6}
-              sequences={
+          <div>
+            <Connect(MSABasicLayout)
+              forwardedPropsKeys={
                 Array [
-                  Object {
-                    "name": "sequence 1",
-                    "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                  },
-                  Object {
-                    "name": "sequence 2",
-                    "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 3",
-                    "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 4",
-                    "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 5",
-                    "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 6",
-                    "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 7",
-                    "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                  },
+                  "sequenceViewerProps",
+                  "labelsProps",
+                  "positionBarProps",
+                  "overviewBarProps",
                 ]
               }
-              style={
-                Object {
-                  "paddingTop": 70,
-                }
-              }
-              tileComponent={[Function]}
-              tileHeight={20}
             >
-              <YBarComponent
-                cacheElements={10}
-                componentCache={[Function]}
-                height={100}
-                nrYTiles={6}
-                position={
-                  Object {
-                    "currentViewSequence": 0,
-                    "currentViewSequencePosition": 0,
-                    "lastCurrentViewSequence": 0,
-                    "lastStartYTile": 0,
-                    "xPos": 0,
-                    "xPosOffset": -0,
-                    "yPos": 0,
-                    "yPosOffset": -0,
-                  }
-                }
-                positionDispatch={[Function]}
-                sequences={
-                  Array [
-                    Object {
-                      "name": "sequence 1",
-                      "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                    },
-                    Object {
-                      "name": "sequence 2",
-                      "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 3",
-                      "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 4",
-                      "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 5",
-                      "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 6",
-                      "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 7",
-                      "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                    },
-                  ]
-                }
-                style={
-                  Object {
-                    "paddingTop": 70,
-                  }
-                }
-                tileComponent={[Function]}
-                tileHeight={20}
-              >
-                <div
-                  style={
-                    Object {
-                      "paddingTop": 70,
-                    }
-                  }
-                >
-                  <div
-                    style={
-                      Object {
-                        "height": 100,
-                        "overflow": "hidden",
-                        "position": "relative",
-                        "whiteSpace": "nowrap",
-                      }
-                    }
-                  >
-                    <ListComponent
-                      componentCache={[Function]}
-                      endTile={7}
-                      startTile={0}
-                      tileComponent={[Function]}
-                    >
-                      <div>
-                        <Label
-                          index={0}
-                          key="0"
-                        >
-                          <div
-                            style={
-                              Object {
-                                "height": 20,
-                              }
-                            }
-                          >
-                            sequence 1
-                          </div>
-                        </Label>
-                        <Label
-                          index={1}
-                          key="1"
-                        >
-                          <div
-                            style={
-                              Object {
-                                "height": 20,
-                              }
-                            }
-                          >
-                            sequence 2
-                          </div>
-                        </Label>
-                        <Label
-                          index={2}
-                          key="2"
-                        >
-                          <div
-                            style={
-                              Object {
-                                "height": 20,
-                              }
-                            }
-                          >
-                            sequence 3
-                          </div>
-                        </Label>
-                        <Label
-                          index={3}
-                          key="3"
-                        >
-                          <div
-                            style={
-                              Object {
-                                "height": 20,
-                              }
-                            }
-                          >
-                            sequence 4
-                          </div>
-                        </Label>
-                        <Label
-                          index={4}
-                          key="4"
-                        >
-                          <div
-                            style={
-                              Object {
-                                "height": 20,
-                              }
-                            }
-                          >
-                            sequence 5
-                          </div>
-                        </Label>
-                        <Label
-                          index={5}
-                          key="5"
-                        >
-                          <div
-                            style={
-                              Object {
-                                "height": 20,
-                              }
-                            }
-                          >
-                            sequence 6
-                          </div>
-                        </Label>
-                        <Label
-                          index={6}
-                          key="6"
-                        >
-                          <div
-                            style={
-                              Object {
-                                "height": 20,
-                              }
-                            }
-                          >
-                            sequence 7
-                          </div>
-                        </Label>
-                      </div>
-                    </ListComponent>
-                  </div>
-                </div>
-              </YBarComponent>
-            </withPosition(YBarComponent)>
-          </HTMLLabelsComponent>
-        </Connect(HTMLLabelsComponent)>
-        <div>
-          <Connect(HTMLOverviewBarComponent)
-            height={50}
-          >
-            <HTMLOverviewBarComponent
-              cacheElements={10}
-              dispatch={[Function]}
-              fillColor="#999999"
-              height={50}
-              maxLength={60}
-              method="conservation"
-              nrXTiles={26}
-              sequences={
-                Array [
-                  Object {
-                    "name": "sequence 1",
-                    "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                  },
-                  Object {
-                    "name": "sequence 2",
-                    "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 3",
-                    "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 4",
-                    "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 5",
-                    "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 6",
-                    "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 7",
-                    "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                  },
-                ]
-              }
-              tileWidth={20}
-              width={500}
-            >
-              <withPosition(XBarComponent)
-                cacheElements={10}
-                componentCache={[Function]}
-                maxLength={60}
-                nrXTiles={26}
-                sequences={
-                  Array [
-                    Object {
-                      "name": "sequence 1",
-                      "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                    },
-                    Object {
-                      "name": "sequence 2",
-                      "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 3",
-                      "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 4",
-                      "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 5",
-                      "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 6",
-                      "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 7",
-                      "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                    },
-                  ]
-                }
-                tileComponent={[Function]}
-                tileWidth={20}
-                width={500}
-              >
-                <XBarComponent
-                  cacheElements={10}
-                  componentCache={[Function]}
-                  maxLength={60}
-                  nrXTiles={26}
-                  position={
-                    Object {
-                      "currentViewSequence": 0,
-                      "currentViewSequencePosition": 0,
-                      "lastCurrentViewSequencePosition": 0,
-                      "lastStartXTile": 0,
-                      "xPos": 0,
-                      "xPosOffset": -0,
-                      "yPos": 0,
-                      "yPosOffset": -0,
-                    }
-                  }
-                  positionDispatch={[Function]}
-                  sequences={
-                    Array [
-                      Object {
-                        "name": "sequence 1",
-                        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                      },
-                      Object {
-                        "name": "sequence 2",
-                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 3",
-                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 4",
-                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 5",
-                        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 6",
-                        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 7",
-                        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                      },
-                    ]
-                  }
-                  tileComponent={[Function]}
-                  tileWidth={20}
-                  width={500}
-                >
-                  <div
-                    style={
-                      Object {
-                        "height": undefined,
-                      }
-                    }
-                  >
-                    <div
-                      style={
-                        Object {
-                          "overflow": "hidden",
-                          "position": "relative",
-                          "whiteSpace": "nowrap",
-                          "width": 500,
-                        }
-                      }
-                    >
-                      <ListComponent
-                        componentCache={[Function]}
-                        endTile={46}
-                        maxWidth={900}
-                        sequences={
-                          Array [
-                            Object {
-                              "name": "sequence 1",
-                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                            },
-                            Object {
-                              "name": "sequence 2",
-                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 3",
-                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 4",
-                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 5",
-                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 6",
-                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 7",
-                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                            },
-                          ]
-                        }
-                        startTile={0}
-                        tileComponent={[Function]}
-                        tileWidth={20}
-                      >
-                        <div>
-                          <Bar
-                            index={0}
-                            key="0"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={1}
-                            key="1"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={2}
-                            key="2"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={3}
-                            key="3"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={4}
-                            key="4"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={5}
-                            key="5"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 34,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={6}
-                            key="6"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={7}
-                            key="7"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 32,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={8}
-                            key="8"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={9}
-                            key="9"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 35,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={10}
-                            key="10"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 28,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={11}
-                            key="11"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 21,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={12}
-                            key="12"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={13}
-                            key="13"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={14}
-                            key="14"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={15}
-                            key="15"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={16}
-                            key="16"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 35,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={17}
-                            key="17"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={18}
-                            key="18"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={19}
-                            key="19"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={20}
-                            key="20"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={21}
-                            key="21"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={22}
-                            key="22"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={23}
-                            key="23"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={24}
-                            key="24"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 35,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={25}
-                            key="25"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 35,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={26}
-                            key="26"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={27}
-                            key="27"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={28}
-                            key="28"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 35,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={29}
-                            key="29"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={30}
-                            key="30"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={31}
-                            key="31"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={32}
-                            key="32"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={33}
-                            key="33"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={34}
-                            key="34"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 35,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={35}
-                            key="35"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={36}
-                            key="36"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={37}
-                            key="37"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={38}
-                            key="38"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={39}
-                            key="39"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 35,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={40}
-                            key="40"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 35,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={41}
-                            key="41"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={42}
-                            key="42"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 35,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={43}
-                            key="43"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 35,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={44}
-                            key="44"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 35,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={45}
-                            key="45"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                        </div>
-                      </ListComponent>
-                    </div>
-                  </div>
-                </XBarComponent>
-              </withPosition(XBarComponent)>
-            </HTMLOverviewBarComponent>
-          </Connect(HTMLOverviewBarComponent)>
-          <Connect(HTMLPositionBarComponent)>
-            <HTMLPositionBarComponent
-              cacheElements={10}
-              dispatch={[Function]}
-              height={15}
-              markerSteps={2}
-              markerStyle={Object {}}
-              maxLength={60}
-              nrXTiles={26}
-              sequences={
-                Array [
-                  Object {
-                    "name": "sequence 1",
-                    "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                  },
-                  Object {
-                    "name": "sequence 2",
-                    "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 3",
-                    "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 4",
-                    "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 5",
-                    "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 6",
-                    "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 7",
-                    "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                  },
-                ]
-              }
-              startIndex={1}
-              style={
-                Object {
-                  "font": "12px Arial",
-                }
-              }
-              tileWidth={20}
-              width={500}
-            >
-              <withPosition(XBarComponent)
-                cacheElements={10}
-                componentCache={[Function]}
-                height={15}
-                maxLength={60}
-                nrXTiles={26}
-                sequences={
-                  Array [
-                    Object {
-                      "name": "sequence 1",
-                      "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                    },
-                    Object {
-                      "name": "sequence 2",
-                      "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 3",
-                      "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 4",
-                      "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 5",
-                      "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 6",
-                      "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 7",
-                      "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                    },
-                  ]
-                }
-                style={
-                  Object {
-                    "font": "12px Arial",
-                  }
-                }
-                tileComponent={[Function]}
-                tileWidth={20}
-                width={500}
-              >
-                <XBarComponent
-                  cacheElements={10}
-                  componentCache={[Function]}
-                  height={15}
-                  maxLength={60}
-                  nrXTiles={26}
-                  position={
-                    Object {
-                      "currentViewSequence": 0,
-                      "currentViewSequencePosition": 0,
-                      "lastCurrentViewSequencePosition": 0,
-                      "lastStartXTile": 0,
-                      "xPos": 0,
-                      "xPosOffset": -0,
-                      "yPos": 0,
-                      "yPosOffset": -0,
-                    }
-                  }
-                  positionDispatch={[Function]}
-                  sequences={
-                    Array [
-                      Object {
-                        "name": "sequence 1",
-                        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                      },
-                      Object {
-                        "name": "sequence 2",
-                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 3",
-                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 4",
-                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 5",
-                        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 6",
-                        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 7",
-                        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                      },
-                    ]
-                  }
-                  style={
-                    Object {
-                      "font": "12px Arial",
-                    }
-                  }
-                  tileComponent={[Function]}
-                  tileWidth={20}
-                  width={500}
-                >
-                  <div
-                    height={15}
-                    style={
-                      Object {
-                        "font": "12px Arial",
-                      }
-                    }
-                  >
-                    <div
-                      style={
-                        Object {
-                          "overflow": "hidden",
-                          "position": "relative",
-                          "whiteSpace": "nowrap",
-                          "width": 500,
-                        }
-                      }
-                    >
-                      <ListComponent
-                        componentCache={[Function]}
-                        endTile={46}
-                        maxWidth={900}
-                        sequences={
-                          Array [
-                            Object {
-                              "name": "sequence 1",
-                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                            },
-                            Object {
-                              "name": "sequence 2",
-                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 3",
-                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 4",
-                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 5",
-                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 6",
-                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 7",
-                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                            },
-                          ]
-                        }
-                        startTile={0}
-                        tileComponent={[Function]}
-                        tileWidth={20}
-                      >
-                        <div>
-                          <Marker
-                            index={0}
-                            key="0"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              1
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={1}
-                            key="1"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={2}
-                            key="2"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              3
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={3}
-                            key="3"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={4}
-                            key="4"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              5
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={5}
-                            key="5"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={6}
-                            key="6"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              7
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={7}
-                            key="7"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={8}
-                            key="8"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              9
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={9}
-                            key="9"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={10}
-                            key="10"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              11
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={11}
-                            key="11"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={12}
-                            key="12"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              13
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={13}
-                            key="13"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={14}
-                            key="14"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              15
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={15}
-                            key="15"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={16}
-                            key="16"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              17
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={17}
-                            key="17"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={18}
-                            key="18"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              19
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={19}
-                            key="19"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={20}
-                            key="20"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              21
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={21}
-                            key="21"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={22}
-                            key="22"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              23
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={23}
-                            key="23"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={24}
-                            key="24"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              25
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={25}
-                            key="25"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={26}
-                            key="26"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              27
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={27}
-                            key="27"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={28}
-                            key="28"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              29
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={29}
-                            key="29"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={30}
-                            key="30"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              31
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={31}
-                            key="31"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={32}
-                            key="32"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              33
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={33}
-                            key="33"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={34}
-                            key="34"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              35
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={35}
-                            key="35"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={36}
-                            key="36"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              37
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={37}
-                            key="37"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={38}
-                            key="38"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              39
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={39}
-                            key="39"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={40}
-                            key="40"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              41
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={41}
-                            key="41"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={42}
-                            key="42"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              43
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={43}
-                            key="43"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={44}
-                            key="44"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              45
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={45}
-                            key="45"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                        </div>
-                      </ListComponent>
-                    </div>
-                  </div>
-                </XBarComponent>
-              </withPosition(XBarComponent)>
-            </HTMLPositionBarComponent>
-          </Connect(HTMLPositionBarComponent)>
-          <Connect(withPosition(SequenceViewerComponent))
-            onResidueClick={[Function]}
-          >
-            <withPosition(SequenceViewerComponent)
-              colorScheme={
-                ColorScheme {
-                  "scheme": StaticSchemeClass {
-                    "defaultColor": "#ffffff",
-                    "getColor": [Function],
-                    "map": Object {
-                      "A": "orange",
-                      "B": "#fff",
-                      "C": "green",
-                      "D": "red",
-                      "E": "red",
-                      "F": "blue",
-                      "G": "orange",
-                      "Gap": "#fff",
-                      "H": "red",
-                      "I": "green",
-                      "J": "#fff",
-                      "K": "red",
-                      "L": "green",
-                      "M": "green",
-                      "N": "#fff",
-                      "O": "#fff",
-                      "P": "orange",
-                      "Q": "#fff",
-                      "R": "red",
-                      "S": "orange",
-                      "T": "orange",
-                      "U": "#fff",
-                      "V": "green",
-                      "W": "blue",
-                      "X": "#fff",
-                      "Y": "blue",
-                      "Z": "#fff",
-                    },
-                    "type": "static",
-                  },
-                }
-              }
-              dispatch={[Function]}
-              fullHeight={140}
-              fullWidth={1200}
-              height={100}
-              nrXTiles={26}
-              nrYTiles={6}
-              onResidueClick={[Function]}
-              sequences={
-                Object {
-                  "length": 7,
-                  "maxLength": 60,
-                  "raw": Array [
-                    Object {
-                      "name": "sequence 1",
-                      "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                    },
-                    Object {
-                      "name": "sequence 2",
-                      "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 3",
-                      "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 4",
-                      "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 5",
-                      "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 6",
-                      "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 7",
-                      "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                    },
-                  ],
-                }
-              }
-              tileHeight={20}
-              tileWidth={20}
-              width={500}
-            >
-              <SequenceViewerComponent
-                border={false}
-                borderColor="black"
-                borderWidth={1}
-                cacheElements={20}
-                colorScheme={
-                  ColorScheme {
-                    "scheme": StaticSchemeClass {
-                      "defaultColor": "#ffffff",
-                      "getColor": [Function],
-                      "map": Object {
-                        "A": "orange",
-                        "B": "#fff",
-                        "C": "green",
-                        "D": "red",
-                        "E": "red",
-                        "F": "blue",
-                        "G": "orange",
-                        "Gap": "#fff",
-                        "H": "red",
-                        "I": "green",
-                        "J": "#fff",
-                        "K": "red",
-                        "L": "green",
-                        "M": "green",
-                        "N": "#fff",
-                        "O": "#fff",
-                        "P": "orange",
-                        "Q": "#fff",
-                        "R": "red",
-                        "S": "orange",
-                        "T": "orange",
-                        "U": "#fff",
-                        "V": "green",
-                        "W": "blue",
-                        "X": "#fff",
-                        "Y": "blue",
-                        "Z": "#fff",
-                      },
-                      "type": "static",
-                    },
-                  }
-                }
+              <MSABasicLayout
                 dispatch={[Function]}
-                fullHeight={140}
-                fullWidth={1200}
-                height={100}
-                nrXTiles={26}
-                nrYTiles={6}
-                onResidueClick={[Function]}
-                overflow="hidden"
-                overflowX="auto"
-                overflowY="auto"
-                position={
-                  Object {
-                    "currentViewSequence": 0,
-                    "currentViewSequencePosition": 0,
-                    "xPos": 0,
-                    "xPosOffset": -0,
-                    "yPos": 0,
-                    "yPosOffset": -0,
-                  }
+                forwardedPropsKeys={
+                  Array [
+                    "sequenceViewerProps",
+                    "labelsProps",
+                    "positionBarProps",
+                    "overviewBarProps",
+                  ]
                 }
-                positionDispatch={[Function]}
-                scrollBarPositionX="bottom"
-                scrollBarPositionY="right"
-                sequences={
-                  Object {
-                    "length": 7,
-                    "maxLength": 60,
-                    "raw": Array [
-                      Object {
-                        "name": "sequence 1",
-                        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                      },
-                      Object {
-                        "name": "sequence 2",
-                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 3",
-                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 4",
-                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 5",
-                        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 6",
-                        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 7",
-                        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                      },
-                    ],
-                  }
-                }
-                showModBar={false}
-                textColor="black"
-                textFont="18px Arial"
                 tileHeight={20}
-                tileWidth={20}
-                width={500}
-                xGridSize={10}
-                yGridSize={10}
               >
                 <div
-                  height={100}
                   style={
                     Object {
-                      "cursor": "grab",
-                      "height": 100,
-                      "position": "relative",
-                      "width": 500,
+                      "display": "flex",
                     }
                   }
-                  width={500}
                 >
-                  <canvas
-                    height={100}
+                  <Connect(HTMLLabelsComponent)
                     style={
                       Object {
-                        "left": 0,
-                        "position": "absolute",
-                        "top": 0,
+                        "paddingTop": 70,
                       }
                     }
-                    width={500}
                   >
-                    Your browser does not seem to support HTML5 canvas.
-                  </canvas>
-                  <canvas
-                    height={100}
-                    style={
-                      Object {
-                        "left": 0,
-                        "position": "absolute",
-                        "top": 0,
-                      }
-                    }
-                    width={500}
-                  >
-                    Your browser does not seem to support HTML5 canvas.
-                  </canvas>
-                  <withPosition(FakeScroll)
-                    fullHeight={140}
-                    fullWidth={1200}
-                    height={100}
-                    overflow="hidden"
-                    overflowX="auto"
-                    overflowY="auto"
-                    positionX="bottom"
-                    positionY="right"
-                    width={500}
-                  >
-                    <FakeScroll
-                      fullHeight={140}
-                      fullWidth={1200}
+                    <HTMLLabelsComponent
+                      cacheElements={10}
+                      dispatch={[Function]}
                       height={100}
-                      overflow="hidden"
-                      overflowX="auto"
-                      overflowY="auto"
-                      position={
+                      labelStyle={Object {}}
+                      nrYTiles={6}
+                      sequences={
+                        Array [
+                          Object {
+                            "name": "sequence 1",
+                            "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                          },
+                          Object {
+                            "name": "sequence 2",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 3",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 4",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 5",
+                            "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 6",
+                            "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 7",
+                            "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                          },
+                        ]
+                      }
+                      style={
                         Object {
-                          "currentViewSequence": 0,
-                          "currentViewSequencePosition": 0,
-                          "xPos": 0,
-                          "xPosOffset": -0,
-                          "yPos": 0,
-                          "yPosOffset": -0,
+                          "paddingTop": 70,
                         }
                       }
-                      positionDispatch={[Function]}
-                      positionX="bottom"
-                      positionY="right"
-                      scrollBarWidth={5}
-                      width={500}
+                      tileHeight={20}
                     >
-                      <div />
-                    </FakeScroll>
-                  </withPosition(FakeScroll)>
+                      <withPosition(YBarComponent)
+                        cacheElements={10}
+                        componentCache={[Function]}
+                        height={100}
+                        nrYTiles={6}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        style={
+                          Object {
+                            "paddingTop": 70,
+                          }
+                        }
+                        tileComponent={[Function]}
+                        tileHeight={20}
+                      >
+                        <YBarComponent
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          height={100}
+                          nrYTiles={6}
+                          position={
+                            Object {
+                              "currentViewSequence": 0,
+                              "currentViewSequencePosition": 0,
+                              "lastCurrentViewSequence": 0,
+                              "lastStartYTile": 0,
+                              "xPos": 0,
+                              "xPosOffset": -0,
+                              "yPos": 0,
+                              "yPosOffset": -0,
+                            }
+                          }
+                          positionDispatch={[Function]}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          style={
+                            Object {
+                              "paddingTop": 70,
+                            }
+                          }
+                          tileComponent={[Function]}
+                          tileHeight={20}
+                        >
+                          <div
+                            style={
+                              Object {
+                                "paddingTop": 70,
+                              }
+                            }
+                          >
+                            <div
+                              style={
+                                Object {
+                                  "height": 100,
+                                  "overflow": "hidden",
+                                  "position": "relative",
+                                  "whiteSpace": "nowrap",
+                                }
+                              }
+                            >
+                              <ListComponent
+                                componentCache={[Function]}
+                                endTile={7}
+                                startTile={0}
+                                tileComponent={[Function]}
+                              >
+                                <div>
+                                  <Label
+                                    index={0}
+                                    key="0"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 1
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={1}
+                                    key="1"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 2
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={2}
+                                    key="2"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 3
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={3}
+                                    key="3"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 4
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={4}
+                                    key="4"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 5
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={5}
+                                    key="5"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 6
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={6}
+                                    key="6"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 7
+                                    </div>
+                                  </Label>
+                                </div>
+                              </ListComponent>
+                            </div>
+                          </div>
+                        </YBarComponent>
+                      </withPosition(YBarComponent)>
+                    </HTMLLabelsComponent>
+                  </Connect(HTMLLabelsComponent)>
+                  <div>
+                    <Connect(HTMLOverviewBarComponent)
+                      height={50}
+                    >
+                      <HTMLOverviewBarComponent
+                        cacheElements={10}
+                        dispatch={[Function]}
+                        fillColor="#999999"
+                        height={50}
+                        maxLength={60}
+                        method="conservation"
+                        nrXTiles={26}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        tileWidth={20}
+                        width={500}
+                      >
+                        <withPosition(XBarComponent)
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          maxLength={60}
+                          nrXTiles={26}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          tileComponent={[Function]}
+                          tileWidth={20}
+                          width={500}
+                        >
+                          <XBarComponent
+                            cacheElements={10}
+                            componentCache={[Function]}
+                            maxLength={60}
+                            nrXTiles={26}
+                            position={
+                              Object {
+                                "currentViewSequence": 0,
+                                "currentViewSequencePosition": 0,
+                                "lastCurrentViewSequencePosition": 0,
+                                "lastStartXTile": 0,
+                                "xPos": 0,
+                                "xPosOffset": -0,
+                                "yPos": 0,
+                                "yPosOffset": -0,
+                              }
+                            }
+                            positionDispatch={[Function]}
+                            sequences={
+                              Array [
+                                Object {
+                                  "name": "sequence 1",
+                                  "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                },
+                                Object {
+                                  "name": "sequence 2",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 3",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 4",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 5",
+                                  "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 6",
+                                  "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 7",
+                                  "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                },
+                              ]
+                            }
+                            tileComponent={[Function]}
+                            tileWidth={20}
+                            width={500}
+                          >
+                            <div
+                              style={
+                                Object {
+                                  "height": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                style={
+                                  Object {
+                                    "overflow": "hidden",
+                                    "position": "relative",
+                                    "whiteSpace": "nowrap",
+                                    "width": 500,
+                                  }
+                                }
+                              >
+                                <ListComponent
+                                  componentCache={[Function]}
+                                  endTile={46}
+                                  maxWidth={900}
+                                  sequences={
+                                    Array [
+                                      Object {
+                                        "name": "sequence 1",
+                                        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                      },
+                                      Object {
+                                        "name": "sequence 2",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 3",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 4",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 5",
+                                        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 6",
+                                        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 7",
+                                        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                      },
+                                    ]
+                                  }
+                                  startTile={0}
+                                  tileComponent={[Function]}
+                                  tileWidth={20}
+                                >
+                                  <div>
+                                    <Bar
+                                      index={0}
+                                      key="0"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={1}
+                                      key="1"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={2}
+                                      key="2"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={3}
+                                      key="3"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={4}
+                                      key="4"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={5}
+                                      key="5"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 34,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={6}
+                                      key="6"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={7}
+                                      key="7"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 32,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={8}
+                                      key="8"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={9}
+                                      key="9"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={10}
+                                      key="10"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 28,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={11}
+                                      key="11"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 21,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={12}
+                                      key="12"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={13}
+                                      key="13"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={14}
+                                      key="14"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={15}
+                                      key="15"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={16}
+                                      key="16"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={17}
+                                      key="17"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={18}
+                                      key="18"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={19}
+                                      key="19"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={20}
+                                      key="20"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={21}
+                                      key="21"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={22}
+                                      key="22"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={23}
+                                      key="23"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={24}
+                                      key="24"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={25}
+                                      key="25"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={26}
+                                      key="26"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={27}
+                                      key="27"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={28}
+                                      key="28"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={29}
+                                      key="29"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={30}
+                                      key="30"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={31}
+                                      key="31"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={32}
+                                      key="32"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={33}
+                                      key="33"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={34}
+                                      key="34"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={35}
+                                      key="35"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={36}
+                                      key="36"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={37}
+                                      key="37"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={38}
+                                      key="38"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={39}
+                                      key="39"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={40}
+                                      key="40"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={41}
+                                      key="41"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={42}
+                                      key="42"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={43}
+                                      key="43"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={44}
+                                      key="44"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={45}
+                                      key="45"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                  </div>
+                                </ListComponent>
+                              </div>
+                            </div>
+                          </XBarComponent>
+                        </withPosition(XBarComponent)>
+                      </HTMLOverviewBarComponent>
+                    </Connect(HTMLOverviewBarComponent)>
+                    <Connect(HTMLPositionBarComponent)>
+                      <HTMLPositionBarComponent
+                        cacheElements={10}
+                        dispatch={[Function]}
+                        height={15}
+                        markerSteps={2}
+                        markerStyle={Object {}}
+                        maxLength={60}
+                        nrXTiles={26}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        startIndex={1}
+                        style={
+                          Object {
+                            "font": "12px Arial",
+                          }
+                        }
+                        tileWidth={20}
+                        width={500}
+                      >
+                        <withPosition(XBarComponent)
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          height={15}
+                          maxLength={60}
+                          nrXTiles={26}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          style={
+                            Object {
+                              "font": "12px Arial",
+                            }
+                          }
+                          tileComponent={[Function]}
+                          tileWidth={20}
+                          width={500}
+                        >
+                          <XBarComponent
+                            cacheElements={10}
+                            componentCache={[Function]}
+                            height={15}
+                            maxLength={60}
+                            nrXTiles={26}
+                            position={
+                              Object {
+                                "currentViewSequence": 0,
+                                "currentViewSequencePosition": 0,
+                                "lastCurrentViewSequencePosition": 0,
+                                "lastStartXTile": 0,
+                                "xPos": 0,
+                                "xPosOffset": -0,
+                                "yPos": 0,
+                                "yPosOffset": -0,
+                              }
+                            }
+                            positionDispatch={[Function]}
+                            sequences={
+                              Array [
+                                Object {
+                                  "name": "sequence 1",
+                                  "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                },
+                                Object {
+                                  "name": "sequence 2",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 3",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 4",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 5",
+                                  "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 6",
+                                  "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 7",
+                                  "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                },
+                              ]
+                            }
+                            style={
+                              Object {
+                                "font": "12px Arial",
+                              }
+                            }
+                            tileComponent={[Function]}
+                            tileWidth={20}
+                            width={500}
+                          >
+                            <div
+                              height={15}
+                              style={
+                                Object {
+                                  "font": "12px Arial",
+                                }
+                              }
+                            >
+                              <div
+                                style={
+                                  Object {
+                                    "overflow": "hidden",
+                                    "position": "relative",
+                                    "whiteSpace": "nowrap",
+                                    "width": 500,
+                                  }
+                                }
+                              >
+                                <ListComponent
+                                  componentCache={[Function]}
+                                  endTile={46}
+                                  maxWidth={900}
+                                  sequences={
+                                    Array [
+                                      Object {
+                                        "name": "sequence 1",
+                                        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                      },
+                                      Object {
+                                        "name": "sequence 2",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 3",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 4",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 5",
+                                        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 6",
+                                        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 7",
+                                        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                      },
+                                    ]
+                                  }
+                                  startTile={0}
+                                  tileComponent={[Function]}
+                                  tileWidth={20}
+                                >
+                                  <div>
+                                    <Marker
+                                      index={0}
+                                      key="0"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        1
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={1}
+                                      key="1"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={2}
+                                      key="2"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        3
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={3}
+                                      key="3"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={4}
+                                      key="4"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        5
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={5}
+                                      key="5"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={6}
+                                      key="6"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        7
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={7}
+                                      key="7"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={8}
+                                      key="8"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        9
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={9}
+                                      key="9"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={10}
+                                      key="10"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        11
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={11}
+                                      key="11"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={12}
+                                      key="12"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        13
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={13}
+                                      key="13"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={14}
+                                      key="14"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        15
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={15}
+                                      key="15"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={16}
+                                      key="16"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        17
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={17}
+                                      key="17"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={18}
+                                      key="18"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        19
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={19}
+                                      key="19"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={20}
+                                      key="20"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        21
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={21}
+                                      key="21"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={22}
+                                      key="22"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        23
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={23}
+                                      key="23"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={24}
+                                      key="24"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        25
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={25}
+                                      key="25"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={26}
+                                      key="26"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        27
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={27}
+                                      key="27"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={28}
+                                      key="28"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        29
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={29}
+                                      key="29"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={30}
+                                      key="30"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        31
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={31}
+                                      key="31"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={32}
+                                      key="32"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        33
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={33}
+                                      key="33"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={34}
+                                      key="34"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        35
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={35}
+                                      key="35"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={36}
+                                      key="36"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        37
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={37}
+                                      key="37"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={38}
+                                      key="38"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        39
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={39}
+                                      key="39"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={40}
+                                      key="40"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        41
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={41}
+                                      key="41"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={42}
+                                      key="42"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        43
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={43}
+                                      key="43"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={44}
+                                      key="44"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        45
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={45}
+                                      key="45"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                  </div>
+                                </ListComponent>
+                              </div>
+                            </div>
+                          </XBarComponent>
+                        </withPosition(XBarComponent)>
+                      </HTMLPositionBarComponent>
+                    </Connect(HTMLPositionBarComponent)>
+                    <Connect(withPosition(SequenceViewerComponent))>
+                      <withPosition(SequenceViewerComponent)
+                        colorScheme={
+                          ColorScheme {
+                            "scheme": StaticSchemeClass {
+                              "defaultColor": "#ffffff",
+                              "getColor": [Function],
+                              "map": Object {
+                                "A": "orange",
+                                "B": "#fff",
+                                "C": "green",
+                                "D": "red",
+                                "E": "red",
+                                "F": "blue",
+                                "G": "orange",
+                                "Gap": "#fff",
+                                "H": "red",
+                                "I": "green",
+                                "J": "#fff",
+                                "K": "red",
+                                "L": "green",
+                                "M": "green",
+                                "N": "#fff",
+                                "O": "#fff",
+                                "P": "orange",
+                                "Q": "#fff",
+                                "R": "red",
+                                "S": "orange",
+                                "T": "orange",
+                                "U": "#fff",
+                                "V": "green",
+                                "W": "blue",
+                                "X": "#fff",
+                                "Y": "blue",
+                                "Z": "#fff",
+                              },
+                              "type": "static",
+                            },
+                          }
+                        }
+                        dispatch={[Function]}
+                        fullHeight={140}
+                        fullWidth={1200}
+                        height={100}
+                        nrXTiles={26}
+                        nrYTiles={6}
+                        sequences={
+                          Object {
+                            "length": 7,
+                            "maxLength": 60,
+                            "raw": Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ],
+                          }
+                        }
+                        tileHeight={20}
+                        tileWidth={20}
+                        width={500}
+                      >
+                        <SequenceViewerComponent
+                          border={false}
+                          borderColor="black"
+                          borderWidth={1}
+                          cacheElements={20}
+                          colorScheme={
+                            ColorScheme {
+                              "scheme": StaticSchemeClass {
+                                "defaultColor": "#ffffff",
+                                "getColor": [Function],
+                                "map": Object {
+                                  "A": "orange",
+                                  "B": "#fff",
+                                  "C": "green",
+                                  "D": "red",
+                                  "E": "red",
+                                  "F": "blue",
+                                  "G": "orange",
+                                  "Gap": "#fff",
+                                  "H": "red",
+                                  "I": "green",
+                                  "J": "#fff",
+                                  "K": "red",
+                                  "L": "green",
+                                  "M": "green",
+                                  "N": "#fff",
+                                  "O": "#fff",
+                                  "P": "orange",
+                                  "Q": "#fff",
+                                  "R": "red",
+                                  "S": "orange",
+                                  "T": "orange",
+                                  "U": "#fff",
+                                  "V": "green",
+                                  "W": "blue",
+                                  "X": "#fff",
+                                  "Y": "blue",
+                                  "Z": "#fff",
+                                },
+                                "type": "static",
+                              },
+                            }
+                          }
+                          dispatch={[Function]}
+                          fullHeight={140}
+                          fullWidth={1200}
+                          height={100}
+                          nrXTiles={26}
+                          nrYTiles={6}
+                          overflow="hidden"
+                          overflowX="auto"
+                          overflowY="auto"
+                          position={
+                            Object {
+                              "currentViewSequence": 0,
+                              "currentViewSequencePosition": 0,
+                              "xPos": 0,
+                              "xPosOffset": -0,
+                              "yPos": 0,
+                              "yPosOffset": -0,
+                            }
+                          }
+                          positionDispatch={[Function]}
+                          scrollBarPositionX="bottom"
+                          scrollBarPositionY="right"
+                          sequences={
+                            Object {
+                              "length": 7,
+                              "maxLength": 60,
+                              "raw": Array [
+                                Object {
+                                  "name": "sequence 1",
+                                  "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                },
+                                Object {
+                                  "name": "sequence 2",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 3",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 4",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 5",
+                                  "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 6",
+                                  "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 7",
+                                  "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                },
+                              ],
+                            }
+                          }
+                          showModBar={false}
+                          textColor="black"
+                          textFont="18px Arial"
+                          tileHeight={20}
+                          tileWidth={20}
+                          width={500}
+                          xGridSize={10}
+                          yGridSize={10}
+                        >
+                          <div
+                            height={100}
+                            style={
+                              Object {
+                                "cursor": "grab",
+                                "height": 100,
+                                "position": "relative",
+                                "width": 500,
+                              }
+                            }
+                            width={500}
+                          >
+                            <canvas
+                              height={100}
+                              style={
+                                Object {
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "top": 0,
+                                }
+                              }
+                              width={500}
+                            >
+                              Your browser does not seem to support HTML5 canvas.
+                            </canvas>
+                            <canvas
+                              height={100}
+                              style={
+                                Object {
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "top": 0,
+                                }
+                              }
+                              width={500}
+                            >
+                              Your browser does not seem to support HTML5 canvas.
+                            </canvas>
+                            <withPosition(FakeScroll)
+                              fullHeight={140}
+                              fullWidth={1200}
+                              height={100}
+                              overflow="hidden"
+                              overflowX="auto"
+                              overflowY="auto"
+                              positionX="bottom"
+                              positionY="right"
+                              width={500}
+                            >
+                              <FakeScroll
+                                fullHeight={140}
+                                fullWidth={1200}
+                                height={100}
+                                overflow="hidden"
+                                overflowX="auto"
+                                overflowY="auto"
+                                position={
+                                  Object {
+                                    "currentViewSequence": 0,
+                                    "currentViewSequencePosition": 0,
+                                    "xPos": 0,
+                                    "xPosOffset": -0,
+                                    "yPos": 0,
+                                    "yPosOffset": -0,
+                                  }
+                                }
+                                positionDispatch={[Function]}
+                                positionX="bottom"
+                                positionY="right"
+                                scrollBarWidth={5}
+                                width={500}
+                              >
+                                <div />
+                              </FakeScroll>
+                            </withPosition(FakeScroll)>
+                          </div>
+                        </SequenceViewerComponent>
+                      </withPosition(SequenceViewerComponent)>
+                    </Connect(withPosition(SequenceViewerComponent))>
+                    <div
+                      style={
+                        Object {
+                          "height": 10,
+                        }
+                      }
+                    />
+                  </div>
                 </div>
-              </SequenceViewerComponent>
-            </withPosition(SequenceViewerComponent)>
-          </Connect(withPosition(SequenceViewerComponent))>
-          <div
-            style={
-              Object {
-                "height": 10,
-              }
-            }
-          />
-        </div>
+              </MSABasicLayout>
+            </Connect(MSABasicLayout)>
+          </div>
+        </MSALayouter>
       </div>
     </Provider>
   </MSAViewerComponent>
@@ -2631,2489 +2659,2517 @@ exports[`renders without crashing in enzyme 1`] = `
         }
       }
     >
-      <div
-        style={
-          Object {
-            "display": "flex",
-          }
-        }
-      >
-        <Connect(HTMLLabelsComponent)
-          style={
-            Object {
-              "paddingTop": 70,
-            }
-          }
+      <div>
+        <MSALayouter
+          layout="default"
         >
-          <HTMLLabelsComponent
-            cacheElements={10}
-            dispatch={[Function]}
-            height={100}
-            labelStyle={Object {}}
-            nrYTiles={6}
-            sequences={
-              Array [
-                Object {
-                  "name": "sequence 1",
-                  "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                },
-                Object {
-                  "name": "sequence 2",
-                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                },
-                Object {
-                  "name": "sequence 3",
-                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                },
-                Object {
-                  "name": "sequence 4",
-                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                },
-                Object {
-                  "name": "sequence 5",
-                  "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                },
-                Object {
-                  "name": "sequence 6",
-                  "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                },
-                Object {
-                  "name": "sequence 7",
-                  "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                },
-              ]
-            }
-            style={
-              Object {
-                "paddingTop": 70,
-              }
-            }
-            tileHeight={20}
-          >
-            <withPosition(YBarComponent)
-              cacheElements={10}
-              componentCache={[Function]}
-              height={100}
-              nrYTiles={6}
-              sequences={
+          <div>
+            <Connect(MSABasicLayout)
+              forwardedPropsKeys={
                 Array [
-                  Object {
-                    "name": "sequence 1",
-                    "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                  },
-                  Object {
-                    "name": "sequence 2",
-                    "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 3",
-                    "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 4",
-                    "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 5",
-                    "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 6",
-                    "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 7",
-                    "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                  },
+                  "sequenceViewerProps",
+                  "labelsProps",
+                  "positionBarProps",
+                  "overviewBarProps",
                 ]
               }
-              style={
-                Object {
-                  "paddingTop": 70,
-                }
-              }
-              tileComponent={[Function]}
-              tileHeight={20}
             >
-              <YBarComponent
-                cacheElements={10}
-                componentCache={[Function]}
-                height={100}
-                nrYTiles={6}
-                position={
-                  Object {
-                    "currentViewSequence": 0,
-                    "currentViewSequencePosition": 0,
-                    "lastCurrentViewSequence": 0,
-                    "lastStartYTile": 0,
-                    "xPos": 0,
-                    "xPosOffset": -0,
-                    "yPos": 0,
-                    "yPosOffset": -0,
-                  }
-                }
-                positionDispatch={[Function]}
-                sequences={
-                  Array [
-                    Object {
-                      "name": "sequence 1",
-                      "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                    },
-                    Object {
-                      "name": "sequence 2",
-                      "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 3",
-                      "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 4",
-                      "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 5",
-                      "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 6",
-                      "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 7",
-                      "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                    },
-                  ]
-                }
-                style={
-                  Object {
-                    "paddingTop": 70,
-                  }
-                }
-                tileComponent={[Function]}
-                tileHeight={20}
-              >
-                <div
-                  style={
-                    Object {
-                      "paddingTop": 70,
-                    }
-                  }
-                >
-                  <div
-                    style={
-                      Object {
-                        "height": 100,
-                        "overflow": "hidden",
-                        "position": "relative",
-                        "whiteSpace": "nowrap",
-                      }
-                    }
-                  >
-                    <ListComponent
-                      componentCache={[Function]}
-                      endTile={7}
-                      startTile={0}
-                      tileComponent={[Function]}
-                    >
-                      <div>
-                        <Label
-                          index={0}
-                          key="0"
-                        >
-                          <div
-                            style={
-                              Object {
-                                "height": 20,
-                              }
-                            }
-                          >
-                            sequence 1
-                          </div>
-                        </Label>
-                        <Label
-                          index={1}
-                          key="1"
-                        >
-                          <div
-                            style={
-                              Object {
-                                "height": 20,
-                              }
-                            }
-                          >
-                            sequence 2
-                          </div>
-                        </Label>
-                        <Label
-                          index={2}
-                          key="2"
-                        >
-                          <div
-                            style={
-                              Object {
-                                "height": 20,
-                              }
-                            }
-                          >
-                            sequence 3
-                          </div>
-                        </Label>
-                        <Label
-                          index={3}
-                          key="3"
-                        >
-                          <div
-                            style={
-                              Object {
-                                "height": 20,
-                              }
-                            }
-                          >
-                            sequence 4
-                          </div>
-                        </Label>
-                        <Label
-                          index={4}
-                          key="4"
-                        >
-                          <div
-                            style={
-                              Object {
-                                "height": 20,
-                              }
-                            }
-                          >
-                            sequence 5
-                          </div>
-                        </Label>
-                        <Label
-                          index={5}
-                          key="5"
-                        >
-                          <div
-                            style={
-                              Object {
-                                "height": 20,
-                              }
-                            }
-                          >
-                            sequence 6
-                          </div>
-                        </Label>
-                        <Label
-                          index={6}
-                          key="6"
-                        >
-                          <div
-                            style={
-                              Object {
-                                "height": 20,
-                              }
-                            }
-                          >
-                            sequence 7
-                          </div>
-                        </Label>
-                      </div>
-                    </ListComponent>
-                  </div>
-                </div>
-              </YBarComponent>
-            </withPosition(YBarComponent)>
-          </HTMLLabelsComponent>
-        </Connect(HTMLLabelsComponent)>
-        <div>
-          <Connect(HTMLOverviewBarComponent)
-            height={50}
-          >
-            <HTMLOverviewBarComponent
-              cacheElements={10}
-              dispatch={[Function]}
-              fillColor="#999999"
-              height={50}
-              maxLength={60}
-              method="conservation"
-              nrXTiles={26}
-              sequences={
-                Array [
-                  Object {
-                    "name": "sequence 1",
-                    "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                  },
-                  Object {
-                    "name": "sequence 2",
-                    "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 3",
-                    "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 4",
-                    "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 5",
-                    "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 6",
-                    "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 7",
-                    "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                  },
-                ]
-              }
-              tileWidth={20}
-              width={500}
-            >
-              <withPosition(XBarComponent)
-                cacheElements={10}
-                componentCache={[Function]}
-                maxLength={60}
-                nrXTiles={26}
-                sequences={
-                  Array [
-                    Object {
-                      "name": "sequence 1",
-                      "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                    },
-                    Object {
-                      "name": "sequence 2",
-                      "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 3",
-                      "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 4",
-                      "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 5",
-                      "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 6",
-                      "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 7",
-                      "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                    },
-                  ]
-                }
-                tileComponent={[Function]}
-                tileWidth={20}
-                width={500}
-              >
-                <XBarComponent
-                  cacheElements={10}
-                  componentCache={[Function]}
-                  maxLength={60}
-                  nrXTiles={26}
-                  position={
-                    Object {
-                      "currentViewSequence": 0,
-                      "currentViewSequencePosition": 0,
-                      "lastCurrentViewSequencePosition": 0,
-                      "lastStartXTile": 0,
-                      "xPos": 0,
-                      "xPosOffset": -0,
-                      "yPos": 0,
-                      "yPosOffset": -0,
-                    }
-                  }
-                  positionDispatch={[Function]}
-                  sequences={
-                    Array [
-                      Object {
-                        "name": "sequence 1",
-                        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                      },
-                      Object {
-                        "name": "sequence 2",
-                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 3",
-                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 4",
-                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 5",
-                        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 6",
-                        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 7",
-                        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                      },
-                    ]
-                  }
-                  tileComponent={[Function]}
-                  tileWidth={20}
-                  width={500}
-                >
-                  <div
-                    style={
-                      Object {
-                        "height": undefined,
-                      }
-                    }
-                  >
-                    <div
-                      style={
-                        Object {
-                          "overflow": "hidden",
-                          "position": "relative",
-                          "whiteSpace": "nowrap",
-                          "width": 500,
-                        }
-                      }
-                    >
-                      <ListComponent
-                        componentCache={[Function]}
-                        endTile={46}
-                        maxWidth={900}
-                        sequences={
-                          Array [
-                            Object {
-                              "name": "sequence 1",
-                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                            },
-                            Object {
-                              "name": "sequence 2",
-                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 3",
-                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 4",
-                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 5",
-                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 6",
-                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 7",
-                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                            },
-                          ]
-                        }
-                        startTile={0}
-                        tileComponent={[Function]}
-                        tileWidth={20}
-                      >
-                        <div>
-                          <Bar
-                            index={0}
-                            key="0"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={1}
-                            key="1"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={2}
-                            key="2"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={3}
-                            key="3"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={4}
-                            key="4"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={5}
-                            key="5"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 34,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={6}
-                            key="6"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={7}
-                            key="7"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 32,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={8}
-                            key="8"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={9}
-                            key="9"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 35,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={10}
-                            key="10"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 28,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={11}
-                            key="11"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 21,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={12}
-                            key="12"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={13}
-                            key="13"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={14}
-                            key="14"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={15}
-                            key="15"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={16}
-                            key="16"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 35,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={17}
-                            key="17"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={18}
-                            key="18"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={19}
-                            key="19"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={20}
-                            key="20"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={21}
-                            key="21"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={22}
-                            key="22"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={23}
-                            key="23"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={24}
-                            key="24"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 35,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={25}
-                            key="25"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 35,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={26}
-                            key="26"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={27}
-                            key="27"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={28}
-                            key="28"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 35,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={29}
-                            key="29"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={30}
-                            key="30"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={31}
-                            key="31"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={32}
-                            key="32"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={33}
-                            key="33"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={34}
-                            key="34"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 35,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={35}
-                            key="35"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={36}
-                            key="36"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={37}
-                            key="37"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={38}
-                            key="38"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={39}
-                            key="39"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 35,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={40}
-                            key="40"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 35,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={41}
-                            key="41"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={42}
-                            key="42"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 35,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={43}
-                            key="43"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 35,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={44}
-                            key="44"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 35,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                          <Bar
-                            index={45}
-                            key="45"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundColor": "#999999",
-                                  "display": "inline-block",
-                                  "height": 50,
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            />
-                          </Bar>
-                        </div>
-                      </ListComponent>
-                    </div>
-                  </div>
-                </XBarComponent>
-              </withPosition(XBarComponent)>
-            </HTMLOverviewBarComponent>
-          </Connect(HTMLOverviewBarComponent)>
-          <Connect(HTMLPositionBarComponent)>
-            <HTMLPositionBarComponent
-              cacheElements={10}
-              dispatch={[Function]}
-              height={15}
-              markerSteps={2}
-              markerStyle={Object {}}
-              maxLength={60}
-              nrXTiles={26}
-              sequences={
-                Array [
-                  Object {
-                    "name": "sequence 1",
-                    "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                  },
-                  Object {
-                    "name": "sequence 2",
-                    "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 3",
-                    "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 4",
-                    "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 5",
-                    "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 6",
-                    "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                  },
-                  Object {
-                    "name": "sequence 7",
-                    "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                  },
-                ]
-              }
-              startIndex={1}
-              style={
-                Object {
-                  "font": "12px Arial",
-                }
-              }
-              tileWidth={20}
-              width={500}
-            >
-              <withPosition(XBarComponent)
-                cacheElements={10}
-                componentCache={[Function]}
-                height={15}
-                maxLength={60}
-                nrXTiles={26}
-                sequences={
-                  Array [
-                    Object {
-                      "name": "sequence 1",
-                      "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                    },
-                    Object {
-                      "name": "sequence 2",
-                      "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 3",
-                      "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 4",
-                      "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 5",
-                      "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 6",
-                      "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 7",
-                      "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                    },
-                  ]
-                }
-                style={
-                  Object {
-                    "font": "12px Arial",
-                  }
-                }
-                tileComponent={[Function]}
-                tileWidth={20}
-                width={500}
-              >
-                <XBarComponent
-                  cacheElements={10}
-                  componentCache={[Function]}
-                  height={15}
-                  maxLength={60}
-                  nrXTiles={26}
-                  position={
-                    Object {
-                      "currentViewSequence": 0,
-                      "currentViewSequencePosition": 0,
-                      "lastCurrentViewSequencePosition": 0,
-                      "lastStartXTile": 0,
-                      "xPos": 0,
-                      "xPosOffset": -0,
-                      "yPos": 0,
-                      "yPosOffset": -0,
-                    }
-                  }
-                  positionDispatch={[Function]}
-                  sequences={
-                    Array [
-                      Object {
-                        "name": "sequence 1",
-                        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                      },
-                      Object {
-                        "name": "sequence 2",
-                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 3",
-                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 4",
-                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 5",
-                        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 6",
-                        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 7",
-                        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                      },
-                    ]
-                  }
-                  style={
-                    Object {
-                      "font": "12px Arial",
-                    }
-                  }
-                  tileComponent={[Function]}
-                  tileWidth={20}
-                  width={500}
-                >
-                  <div
-                    height={15}
-                    style={
-                      Object {
-                        "font": "12px Arial",
-                      }
-                    }
-                  >
-                    <div
-                      style={
-                        Object {
-                          "overflow": "hidden",
-                          "position": "relative",
-                          "whiteSpace": "nowrap",
-                          "width": 500,
-                        }
-                      }
-                    >
-                      <ListComponent
-                        componentCache={[Function]}
-                        endTile={46}
-                        maxWidth={900}
-                        sequences={
-                          Array [
-                            Object {
-                              "name": "sequence 1",
-                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                            },
-                            Object {
-                              "name": "sequence 2",
-                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 3",
-                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 4",
-                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 5",
-                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 6",
-                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 7",
-                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                            },
-                          ]
-                        }
-                        startTile={0}
-                        tileComponent={[Function]}
-                        tileWidth={20}
-                      >
-                        <div>
-                          <Marker
-                            index={0}
-                            key="0"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              1
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={1}
-                            key="1"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={2}
-                            key="2"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              3
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={3}
-                            key="3"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={4}
-                            key="4"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              5
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={5}
-                            key="5"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={6}
-                            key="6"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              7
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={7}
-                            key="7"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={8}
-                            key="8"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              9
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={9}
-                            key="9"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={10}
-                            key="10"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              11
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={11}
-                            key="11"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={12}
-                            key="12"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              13
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={13}
-                            key="13"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={14}
-                            key="14"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              15
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={15}
-                            key="15"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={16}
-                            key="16"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              17
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={17}
-                            key="17"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={18}
-                            key="18"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              19
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={19}
-                            key="19"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={20}
-                            key="20"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              21
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={21}
-                            key="21"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={22}
-                            key="22"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              23
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={23}
-                            key="23"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={24}
-                            key="24"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              25
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={25}
-                            key="25"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={26}
-                            key="26"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              27
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={27}
-                            key="27"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={28}
-                            key="28"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              29
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={29}
-                            key="29"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={30}
-                            key="30"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              31
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={31}
-                            key="31"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={32}
-                            key="32"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              33
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={33}
-                            key="33"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={34}
-                            key="34"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              35
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={35}
-                            key="35"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={36}
-                            key="36"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              37
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={37}
-                            key="37"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={38}
-                            key="38"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              39
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={39}
-                            key="39"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={40}
-                            key="40"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              41
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={41}
-                            key="41"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={42}
-                            key="42"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              43
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={43}
-                            key="43"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={44}
-                            key="44"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              45
-                            </div>
-                          </Marker>
-                          <Marker
-                            index={45}
-                            key="45"
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "textAlign": "center",
-                                  "width": 20,
-                                }
-                              }
-                            >
-                              .
-                            </div>
-                          </Marker>
-                        </div>
-                      </ListComponent>
-                    </div>
-                  </div>
-                </XBarComponent>
-              </withPosition(XBarComponent)>
-            </HTMLPositionBarComponent>
-          </Connect(HTMLPositionBarComponent)>
-          <Connect(withPosition(SequenceViewerComponent))
-            onResidueClick={[Function]}
-          >
-            <withPosition(SequenceViewerComponent)
-              colorScheme={
-                ColorScheme {
-                  "scheme": StaticSchemeClass {
-                    "defaultColor": "#ffffff",
-                    "getColor": [Function],
-                    "map": Object {
-                      "A": "orange",
-                      "B": "#fff",
-                      "C": "green",
-                      "D": "red",
-                      "E": "red",
-                      "F": "blue",
-                      "G": "orange",
-                      "Gap": "#fff",
-                      "H": "red",
-                      "I": "green",
-                      "J": "#fff",
-                      "K": "red",
-                      "L": "green",
-                      "M": "green",
-                      "N": "#fff",
-                      "O": "#fff",
-                      "P": "orange",
-                      "Q": "#fff",
-                      "R": "red",
-                      "S": "orange",
-                      "T": "orange",
-                      "U": "#fff",
-                      "V": "green",
-                      "W": "blue",
-                      "X": "#fff",
-                      "Y": "blue",
-                      "Z": "#fff",
-                    },
-                    "type": "static",
-                  },
-                }
-              }
-              dispatch={[Function]}
-              fullHeight={140}
-              fullWidth={1200}
-              height={100}
-              nrXTiles={26}
-              nrYTiles={6}
-              onResidueClick={[Function]}
-              sequences={
-                Object {
-                  "length": 7,
-                  "maxLength": 60,
-                  "raw": Array [
-                    Object {
-                      "name": "sequence 1",
-                      "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                    },
-                    Object {
-                      "name": "sequence 2",
-                      "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 3",
-                      "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 4",
-                      "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 5",
-                      "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 6",
-                      "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                    },
-                    Object {
-                      "name": "sequence 7",
-                      "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                    },
-                  ],
-                }
-              }
-              tileHeight={20}
-              tileWidth={20}
-              width={500}
-            >
-              <SequenceViewerComponent
-                border={false}
-                borderColor="black"
-                borderWidth={1}
-                cacheElements={20}
-                colorScheme={
-                  ColorScheme {
-                    "scheme": StaticSchemeClass {
-                      "defaultColor": "#ffffff",
-                      "getColor": [Function],
-                      "map": Object {
-                        "A": "orange",
-                        "B": "#fff",
-                        "C": "green",
-                        "D": "red",
-                        "E": "red",
-                        "F": "blue",
-                        "G": "orange",
-                        "Gap": "#fff",
-                        "H": "red",
-                        "I": "green",
-                        "J": "#fff",
-                        "K": "red",
-                        "L": "green",
-                        "M": "green",
-                        "N": "#fff",
-                        "O": "#fff",
-                        "P": "orange",
-                        "Q": "#fff",
-                        "R": "red",
-                        "S": "orange",
-                        "T": "orange",
-                        "U": "#fff",
-                        "V": "green",
-                        "W": "blue",
-                        "X": "#fff",
-                        "Y": "blue",
-                        "Z": "#fff",
-                      },
-                      "type": "static",
-                    },
-                  }
-                }
+              <MSABasicLayout
                 dispatch={[Function]}
-                fullHeight={140}
-                fullWidth={1200}
-                height={100}
-                nrXTiles={26}
-                nrYTiles={6}
-                onResidueClick={[Function]}
-                overflow="hidden"
-                overflowX="auto"
-                overflowY="auto"
-                position={
-                  Object {
-                    "currentViewSequence": 0,
-                    "currentViewSequencePosition": 0,
-                    "xPos": 0,
-                    "xPosOffset": -0,
-                    "yPos": 0,
-                    "yPosOffset": -0,
-                  }
+                forwardedPropsKeys={
+                  Array [
+                    "sequenceViewerProps",
+                    "labelsProps",
+                    "positionBarProps",
+                    "overviewBarProps",
+                  ]
                 }
-                positionDispatch={[Function]}
-                scrollBarPositionX="bottom"
-                scrollBarPositionY="right"
-                sequences={
-                  Object {
-                    "length": 7,
-                    "maxLength": 60,
-                    "raw": Array [
-                      Object {
-                        "name": "sequence 1",
-                        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                      },
-                      Object {
-                        "name": "sequence 2",
-                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 3",
-                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 4",
-                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 5",
-                        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 6",
-                        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                      },
-                      Object {
-                        "name": "sequence 7",
-                        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                      },
-                    ],
-                  }
-                }
-                showModBar={false}
-                textColor="black"
-                textFont="18px Arial"
                 tileHeight={20}
-                tileWidth={20}
-                width={500}
-                xGridSize={10}
-                yGridSize={10}
               >
                 <div
-                  height={100}
                   style={
                     Object {
-                      "cursor": "grab",
-                      "height": 100,
-                      "position": "relative",
-                      "width": 500,
+                      "display": "flex",
                     }
                   }
-                  width={500}
                 >
-                  <canvas
-                    height={100}
+                  <Connect(HTMLLabelsComponent)
                     style={
                       Object {
-                        "left": 0,
-                        "position": "absolute",
-                        "top": 0,
+                        "paddingTop": 70,
                       }
                     }
-                    width={500}
                   >
-                    Your browser does not seem to support HTML5 canvas.
-                  </canvas>
-                  <canvas
-                    height={100}
-                    style={
-                      Object {
-                        "left": 0,
-                        "position": "absolute",
-                        "top": 0,
-                      }
-                    }
-                    width={500}
-                  >
-                    Your browser does not seem to support HTML5 canvas.
-                  </canvas>
-                  <withPosition(FakeScroll)
-                    fullHeight={140}
-                    fullWidth={1200}
-                    height={100}
-                    overflow="hidden"
-                    overflowX="auto"
-                    overflowY="auto"
-                    positionX="bottom"
-                    positionY="right"
-                    width={500}
-                  >
-                    <FakeScroll
-                      fullHeight={140}
-                      fullWidth={1200}
+                    <HTMLLabelsComponent
+                      cacheElements={10}
+                      dispatch={[Function]}
                       height={100}
-                      overflow="hidden"
-                      overflowX="auto"
-                      overflowY="auto"
-                      position={
+                      labelStyle={Object {}}
+                      nrYTiles={6}
+                      sequences={
+                        Array [
+                          Object {
+                            "name": "sequence 1",
+                            "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                          },
+                          Object {
+                            "name": "sequence 2",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 3",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 4",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 5",
+                            "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 6",
+                            "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 7",
+                            "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                          },
+                        ]
+                      }
+                      style={
                         Object {
-                          "currentViewSequence": 0,
-                          "currentViewSequencePosition": 0,
-                          "xPos": 0,
-                          "xPosOffset": -0,
-                          "yPos": 0,
-                          "yPosOffset": -0,
+                          "paddingTop": 70,
                         }
                       }
-                      positionDispatch={[Function]}
-                      positionX="bottom"
-                      positionY="right"
-                      scrollBarWidth={5}
-                      width={500}
+                      tileHeight={20}
                     >
-                      <div />
-                    </FakeScroll>
-                  </withPosition(FakeScroll)>
+                      <withPosition(YBarComponent)
+                        cacheElements={10}
+                        componentCache={[Function]}
+                        height={100}
+                        nrYTiles={6}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        style={
+                          Object {
+                            "paddingTop": 70,
+                          }
+                        }
+                        tileComponent={[Function]}
+                        tileHeight={20}
+                      >
+                        <YBarComponent
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          height={100}
+                          nrYTiles={6}
+                          position={
+                            Object {
+                              "currentViewSequence": 0,
+                              "currentViewSequencePosition": 0,
+                              "lastCurrentViewSequence": 0,
+                              "lastStartYTile": 0,
+                              "xPos": 0,
+                              "xPosOffset": -0,
+                              "yPos": 0,
+                              "yPosOffset": -0,
+                            }
+                          }
+                          positionDispatch={[Function]}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          style={
+                            Object {
+                              "paddingTop": 70,
+                            }
+                          }
+                          tileComponent={[Function]}
+                          tileHeight={20}
+                        >
+                          <div
+                            style={
+                              Object {
+                                "paddingTop": 70,
+                              }
+                            }
+                          >
+                            <div
+                              style={
+                                Object {
+                                  "height": 100,
+                                  "overflow": "hidden",
+                                  "position": "relative",
+                                  "whiteSpace": "nowrap",
+                                }
+                              }
+                            >
+                              <ListComponent
+                                componentCache={[Function]}
+                                endTile={7}
+                                startTile={0}
+                                tileComponent={[Function]}
+                              >
+                                <div>
+                                  <Label
+                                    index={0}
+                                    key="0"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 1
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={1}
+                                    key="1"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 2
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={2}
+                                    key="2"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 3
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={3}
+                                    key="3"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 4
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={4}
+                                    key="4"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 5
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={5}
+                                    key="5"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 6
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={6}
+                                    key="6"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 7
+                                    </div>
+                                  </Label>
+                                </div>
+                              </ListComponent>
+                            </div>
+                          </div>
+                        </YBarComponent>
+                      </withPosition(YBarComponent)>
+                    </HTMLLabelsComponent>
+                  </Connect(HTMLLabelsComponent)>
+                  <div>
+                    <Connect(HTMLOverviewBarComponent)
+                      height={50}
+                    >
+                      <HTMLOverviewBarComponent
+                        cacheElements={10}
+                        dispatch={[Function]}
+                        fillColor="#999999"
+                        height={50}
+                        maxLength={60}
+                        method="conservation"
+                        nrXTiles={26}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        tileWidth={20}
+                        width={500}
+                      >
+                        <withPosition(XBarComponent)
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          maxLength={60}
+                          nrXTiles={26}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          tileComponent={[Function]}
+                          tileWidth={20}
+                          width={500}
+                        >
+                          <XBarComponent
+                            cacheElements={10}
+                            componentCache={[Function]}
+                            maxLength={60}
+                            nrXTiles={26}
+                            position={
+                              Object {
+                                "currentViewSequence": 0,
+                                "currentViewSequencePosition": 0,
+                                "lastCurrentViewSequencePosition": 0,
+                                "lastStartXTile": 0,
+                                "xPos": 0,
+                                "xPosOffset": -0,
+                                "yPos": 0,
+                                "yPosOffset": -0,
+                              }
+                            }
+                            positionDispatch={[Function]}
+                            sequences={
+                              Array [
+                                Object {
+                                  "name": "sequence 1",
+                                  "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                },
+                                Object {
+                                  "name": "sequence 2",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 3",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 4",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 5",
+                                  "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 6",
+                                  "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 7",
+                                  "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                },
+                              ]
+                            }
+                            tileComponent={[Function]}
+                            tileWidth={20}
+                            width={500}
+                          >
+                            <div
+                              style={
+                                Object {
+                                  "height": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                style={
+                                  Object {
+                                    "overflow": "hidden",
+                                    "position": "relative",
+                                    "whiteSpace": "nowrap",
+                                    "width": 500,
+                                  }
+                                }
+                              >
+                                <ListComponent
+                                  componentCache={[Function]}
+                                  endTile={46}
+                                  maxWidth={900}
+                                  sequences={
+                                    Array [
+                                      Object {
+                                        "name": "sequence 1",
+                                        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                      },
+                                      Object {
+                                        "name": "sequence 2",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 3",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 4",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 5",
+                                        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 6",
+                                        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 7",
+                                        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                      },
+                                    ]
+                                  }
+                                  startTile={0}
+                                  tileComponent={[Function]}
+                                  tileWidth={20}
+                                >
+                                  <div>
+                                    <Bar
+                                      index={0}
+                                      key="0"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={1}
+                                      key="1"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={2}
+                                      key="2"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={3}
+                                      key="3"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={4}
+                                      key="4"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={5}
+                                      key="5"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 34,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={6}
+                                      key="6"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={7}
+                                      key="7"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 32,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={8}
+                                      key="8"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={9}
+                                      key="9"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={10}
+                                      key="10"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 28,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={11}
+                                      key="11"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 21,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={12}
+                                      key="12"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={13}
+                                      key="13"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={14}
+                                      key="14"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={15}
+                                      key="15"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={16}
+                                      key="16"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={17}
+                                      key="17"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={18}
+                                      key="18"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={19}
+                                      key="19"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={20}
+                                      key="20"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={21}
+                                      key="21"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={22}
+                                      key="22"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={23}
+                                      key="23"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={24}
+                                      key="24"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={25}
+                                      key="25"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={26}
+                                      key="26"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={27}
+                                      key="27"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={28}
+                                      key="28"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={29}
+                                      key="29"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={30}
+                                      key="30"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={31}
+                                      key="31"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={32}
+                                      key="32"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={33}
+                                      key="33"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={34}
+                                      key="34"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={35}
+                                      key="35"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={36}
+                                      key="36"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={37}
+                                      key="37"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={38}
+                                      key="38"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={39}
+                                      key="39"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={40}
+                                      key="40"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={41}
+                                      key="41"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={42}
+                                      key="42"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={43}
+                                      key="43"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={44}
+                                      key="44"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={45}
+                                      key="45"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                  </div>
+                                </ListComponent>
+                              </div>
+                            </div>
+                          </XBarComponent>
+                        </withPosition(XBarComponent)>
+                      </HTMLOverviewBarComponent>
+                    </Connect(HTMLOverviewBarComponent)>
+                    <Connect(HTMLPositionBarComponent)>
+                      <HTMLPositionBarComponent
+                        cacheElements={10}
+                        dispatch={[Function]}
+                        height={15}
+                        markerSteps={2}
+                        markerStyle={Object {}}
+                        maxLength={60}
+                        nrXTiles={26}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        startIndex={1}
+                        style={
+                          Object {
+                            "font": "12px Arial",
+                          }
+                        }
+                        tileWidth={20}
+                        width={500}
+                      >
+                        <withPosition(XBarComponent)
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          height={15}
+                          maxLength={60}
+                          nrXTiles={26}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          style={
+                            Object {
+                              "font": "12px Arial",
+                            }
+                          }
+                          tileComponent={[Function]}
+                          tileWidth={20}
+                          width={500}
+                        >
+                          <XBarComponent
+                            cacheElements={10}
+                            componentCache={[Function]}
+                            height={15}
+                            maxLength={60}
+                            nrXTiles={26}
+                            position={
+                              Object {
+                                "currentViewSequence": 0,
+                                "currentViewSequencePosition": 0,
+                                "lastCurrentViewSequencePosition": 0,
+                                "lastStartXTile": 0,
+                                "xPos": 0,
+                                "xPosOffset": -0,
+                                "yPos": 0,
+                                "yPosOffset": -0,
+                              }
+                            }
+                            positionDispatch={[Function]}
+                            sequences={
+                              Array [
+                                Object {
+                                  "name": "sequence 1",
+                                  "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                },
+                                Object {
+                                  "name": "sequence 2",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 3",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 4",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 5",
+                                  "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 6",
+                                  "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 7",
+                                  "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                },
+                              ]
+                            }
+                            style={
+                              Object {
+                                "font": "12px Arial",
+                              }
+                            }
+                            tileComponent={[Function]}
+                            tileWidth={20}
+                            width={500}
+                          >
+                            <div
+                              height={15}
+                              style={
+                                Object {
+                                  "font": "12px Arial",
+                                }
+                              }
+                            >
+                              <div
+                                style={
+                                  Object {
+                                    "overflow": "hidden",
+                                    "position": "relative",
+                                    "whiteSpace": "nowrap",
+                                    "width": 500,
+                                  }
+                                }
+                              >
+                                <ListComponent
+                                  componentCache={[Function]}
+                                  endTile={46}
+                                  maxWidth={900}
+                                  sequences={
+                                    Array [
+                                      Object {
+                                        "name": "sequence 1",
+                                        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                      },
+                                      Object {
+                                        "name": "sequence 2",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 3",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 4",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 5",
+                                        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 6",
+                                        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 7",
+                                        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                      },
+                                    ]
+                                  }
+                                  startTile={0}
+                                  tileComponent={[Function]}
+                                  tileWidth={20}
+                                >
+                                  <div>
+                                    <Marker
+                                      index={0}
+                                      key="0"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        1
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={1}
+                                      key="1"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={2}
+                                      key="2"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        3
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={3}
+                                      key="3"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={4}
+                                      key="4"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        5
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={5}
+                                      key="5"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={6}
+                                      key="6"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        7
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={7}
+                                      key="7"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={8}
+                                      key="8"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        9
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={9}
+                                      key="9"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={10}
+                                      key="10"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        11
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={11}
+                                      key="11"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={12}
+                                      key="12"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        13
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={13}
+                                      key="13"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={14}
+                                      key="14"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        15
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={15}
+                                      key="15"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={16}
+                                      key="16"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        17
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={17}
+                                      key="17"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={18}
+                                      key="18"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        19
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={19}
+                                      key="19"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={20}
+                                      key="20"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        21
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={21}
+                                      key="21"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={22}
+                                      key="22"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        23
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={23}
+                                      key="23"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={24}
+                                      key="24"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        25
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={25}
+                                      key="25"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={26}
+                                      key="26"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        27
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={27}
+                                      key="27"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={28}
+                                      key="28"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        29
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={29}
+                                      key="29"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={30}
+                                      key="30"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        31
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={31}
+                                      key="31"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={32}
+                                      key="32"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        33
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={33}
+                                      key="33"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={34}
+                                      key="34"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        35
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={35}
+                                      key="35"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={36}
+                                      key="36"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        37
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={37}
+                                      key="37"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={38}
+                                      key="38"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        39
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={39}
+                                      key="39"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={40}
+                                      key="40"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        41
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={41}
+                                      key="41"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={42}
+                                      key="42"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        43
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={43}
+                                      key="43"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={44}
+                                      key="44"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        45
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={45}
+                                      key="45"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                  </div>
+                                </ListComponent>
+                              </div>
+                            </div>
+                          </XBarComponent>
+                        </withPosition(XBarComponent)>
+                      </HTMLPositionBarComponent>
+                    </Connect(HTMLPositionBarComponent)>
+                    <Connect(withPosition(SequenceViewerComponent))>
+                      <withPosition(SequenceViewerComponent)
+                        colorScheme={
+                          ColorScheme {
+                            "scheme": StaticSchemeClass {
+                              "defaultColor": "#ffffff",
+                              "getColor": [Function],
+                              "map": Object {
+                                "A": "orange",
+                                "B": "#fff",
+                                "C": "green",
+                                "D": "red",
+                                "E": "red",
+                                "F": "blue",
+                                "G": "orange",
+                                "Gap": "#fff",
+                                "H": "red",
+                                "I": "green",
+                                "J": "#fff",
+                                "K": "red",
+                                "L": "green",
+                                "M": "green",
+                                "N": "#fff",
+                                "O": "#fff",
+                                "P": "orange",
+                                "Q": "#fff",
+                                "R": "red",
+                                "S": "orange",
+                                "T": "orange",
+                                "U": "#fff",
+                                "V": "green",
+                                "W": "blue",
+                                "X": "#fff",
+                                "Y": "blue",
+                                "Z": "#fff",
+                              },
+                              "type": "static",
+                            },
+                          }
+                        }
+                        dispatch={[Function]}
+                        fullHeight={140}
+                        fullWidth={1200}
+                        height={100}
+                        nrXTiles={26}
+                        nrYTiles={6}
+                        sequences={
+                          Object {
+                            "length": 7,
+                            "maxLength": 60,
+                            "raw": Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ],
+                          }
+                        }
+                        tileHeight={20}
+                        tileWidth={20}
+                        width={500}
+                      >
+                        <SequenceViewerComponent
+                          border={false}
+                          borderColor="black"
+                          borderWidth={1}
+                          cacheElements={20}
+                          colorScheme={
+                            ColorScheme {
+                              "scheme": StaticSchemeClass {
+                                "defaultColor": "#ffffff",
+                                "getColor": [Function],
+                                "map": Object {
+                                  "A": "orange",
+                                  "B": "#fff",
+                                  "C": "green",
+                                  "D": "red",
+                                  "E": "red",
+                                  "F": "blue",
+                                  "G": "orange",
+                                  "Gap": "#fff",
+                                  "H": "red",
+                                  "I": "green",
+                                  "J": "#fff",
+                                  "K": "red",
+                                  "L": "green",
+                                  "M": "green",
+                                  "N": "#fff",
+                                  "O": "#fff",
+                                  "P": "orange",
+                                  "Q": "#fff",
+                                  "R": "red",
+                                  "S": "orange",
+                                  "T": "orange",
+                                  "U": "#fff",
+                                  "V": "green",
+                                  "W": "blue",
+                                  "X": "#fff",
+                                  "Y": "blue",
+                                  "Z": "#fff",
+                                },
+                                "type": "static",
+                              },
+                            }
+                          }
+                          dispatch={[Function]}
+                          fullHeight={140}
+                          fullWidth={1200}
+                          height={100}
+                          nrXTiles={26}
+                          nrYTiles={6}
+                          overflow="hidden"
+                          overflowX="auto"
+                          overflowY="auto"
+                          position={
+                            Object {
+                              "currentViewSequence": 0,
+                              "currentViewSequencePosition": 0,
+                              "xPos": 0,
+                              "xPosOffset": -0,
+                              "yPos": 0,
+                              "yPosOffset": -0,
+                            }
+                          }
+                          positionDispatch={[Function]}
+                          scrollBarPositionX="bottom"
+                          scrollBarPositionY="right"
+                          sequences={
+                            Object {
+                              "length": 7,
+                              "maxLength": 60,
+                              "raw": Array [
+                                Object {
+                                  "name": "sequence 1",
+                                  "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                },
+                                Object {
+                                  "name": "sequence 2",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 3",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 4",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 5",
+                                  "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 6",
+                                  "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 7",
+                                  "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                },
+                              ],
+                            }
+                          }
+                          showModBar={false}
+                          textColor="black"
+                          textFont="18px Arial"
+                          tileHeight={20}
+                          tileWidth={20}
+                          width={500}
+                          xGridSize={10}
+                          yGridSize={10}
+                        >
+                          <div
+                            height={100}
+                            style={
+                              Object {
+                                "cursor": "grab",
+                                "height": 100,
+                                "position": "relative",
+                                "width": 500,
+                              }
+                            }
+                            width={500}
+                          >
+                            <canvas
+                              height={100}
+                              style={
+                                Object {
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "top": 0,
+                                }
+                              }
+                              width={500}
+                            >
+                              Your browser does not seem to support HTML5 canvas.
+                            </canvas>
+                            <canvas
+                              height={100}
+                              style={
+                                Object {
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "top": 0,
+                                }
+                              }
+                              width={500}
+                            >
+                              Your browser does not seem to support HTML5 canvas.
+                            </canvas>
+                            <withPosition(FakeScroll)
+                              fullHeight={140}
+                              fullWidth={1200}
+                              height={100}
+                              overflow="hidden"
+                              overflowX="auto"
+                              overflowY="auto"
+                              positionX="bottom"
+                              positionY="right"
+                              width={500}
+                            >
+                              <FakeScroll
+                                fullHeight={140}
+                                fullWidth={1200}
+                                height={100}
+                                overflow="hidden"
+                                overflowX="auto"
+                                overflowY="auto"
+                                position={
+                                  Object {
+                                    "currentViewSequence": 0,
+                                    "currentViewSequencePosition": 0,
+                                    "xPos": 0,
+                                    "xPosOffset": -0,
+                                    "yPos": 0,
+                                    "yPosOffset": -0,
+                                  }
+                                }
+                                positionDispatch={[Function]}
+                                positionX="bottom"
+                                positionY="right"
+                                scrollBarWidth={5}
+                                width={500}
+                              >
+                                <div />
+                              </FakeScroll>
+                            </withPosition(FakeScroll)>
+                          </div>
+                        </SequenceViewerComponent>
+                      </withPosition(SequenceViewerComponent)>
+                    </Connect(withPosition(SequenceViewerComponent))>
+                    <div
+                      style={
+                        Object {
+                          "height": 10,
+                        }
+                      }
+                    />
+                  </div>
                 </div>
-              </SequenceViewerComponent>
-            </withPosition(SequenceViewerComponent)>
-          </Connect(withPosition(SequenceViewerComponent))>
-          <div
-            style={
-              Object {
-                "height": 10,
-              }
-            }
-          />
-        </div>
+              </MSABasicLayout>
+            </Connect(MSABasicLayout)>
+          </div>
+        </MSALayouter>
       </div>
     </Provider>
   </MSAViewerComponent>

--- a/src/components/__snapshots__/MSAViewer.test.js.snap
+++ b/src/components/__snapshots__/MSAViewer.test.js.snap
@@ -2,9 +2,7 @@
 
 exports[`it should rerender when new props are given 1`] = `
 <PropsToReduxComponent
-  backgroundColor="red"
   colorScheme="clustal"
-  engine="canvas"
   height={300}
   sequences={
     Array [
@@ -67,6 +65,7 @@ exports[`it should rerender when new props are given 1`] = `
       <div>
         <MSALayouter
           layout="default"
+          onResidueClick={[Function]}
         >
           <div>
             <Connect(MSABasicLayout)
@@ -2597,9 +2596,7 @@ exports[`renders without crashing 1`] = `
 
 exports[`renders without crashing in enzyme 1`] = `
 <PropsToReduxComponent
-  backgroundColor="red"
   colorScheme="clustal"
-  engine="canvas"
   height={100}
   sequences={
     Array [
@@ -2662,6 +2659,7 @@ exports[`renders without crashing in enzyme 1`] = `
       <div>
         <MSALayouter
           layout="default"
+          onResidueClick={[Function]}
         >
           <div>
             <Connect(MSABasicLayout)

--- a/src/components/layouts/MSALayouter.js
+++ b/src/components/layouts/MSALayouter.js
@@ -22,12 +22,14 @@ import BasicLayout from './basic';
 import InverseLayout from './inverse';
 import FullLayout from './inverse';
 import CompactLayout from './inverse';
+import FunkyLayout from './funky';
 
 const layouts = {
   "basic": BasicLayout,
   "inverse": InverseLayout,
   "full": FullLayout,
   "compact": CompactLayout,
+  "funky": FunkyLayout,
   "default": BasicLayout,
 };
 

--- a/src/components/layouts/MSALayouter.js
+++ b/src/components/layouts/MSALayouter.js
@@ -13,14 +13,16 @@ import createRef from 'create-react-ref/lib/createRef';
 import {
 } from 'lodash-es'
 
-import BasicLayout from './basic';
 import {
   same,
   forwardPropsMapper,
 } from './util';
 
+import BasicLayout from './basic';
+import InverseLayout from './inverse';
 const layouts = {
   "basic": BasicLayout,
+  "inverse": InverseLayout,
   "default": BasicLayout,
 };
 

--- a/src/components/layouts/MSALayouter.js
+++ b/src/components/layouts/MSALayouter.js
@@ -20,9 +20,12 @@ import {
 
 import BasicLayout from './basic';
 import InverseLayout from './inverse';
+import FullLayout from './inverse';
+
 const layouts = {
   "basic": BasicLayout,
   "inverse": InverseLayout,
+  "full": FullLayout,
   "default": BasicLayout,
 };
 

--- a/src/components/layouts/MSALayouter.js
+++ b/src/components/layouts/MSALayouter.js
@@ -72,12 +72,16 @@ class MSALayouter extends PureComponent {
     },
     // List of props forwarded to the PositionBar component
     positionBarProps: {
+      "markerSteps": same,
+      "markerStartIndex": "startIndex",
       "markerComponent": same,
       "markerStyle": same,
       "markerAttributes": same,
     },
     // List of props forwarded to the OverviewBar component
     overviewBarProps: {
+      "barMethod": "method",
+      "barFillColor": "fillColor",
       "barComponent": same,
       "barStyle": same,
       "barAttributes": same,

--- a/src/components/layouts/MSALayouter.js
+++ b/src/components/layouts/MSALayouter.js
@@ -21,11 +21,13 @@ import {
 import BasicLayout from './basic';
 import InverseLayout from './inverse';
 import FullLayout from './inverse';
+import CompactLayout from './inverse';
 
 const layouts = {
   "basic": BasicLayout,
   "inverse": InverseLayout,
   "full": FullLayout,
+  "compact": CompactLayout,
   "default": BasicLayout,
 };
 

--- a/src/components/layouts/MSALayouter.js
+++ b/src/components/layouts/MSALayouter.js
@@ -1,0 +1,109 @@
+/**
+* Copyright 2018, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import createRef from 'create-react-ref/lib/createRef';
+
+import {
+} from 'lodash-es'
+
+import BasicLayout from './basic';
+import {
+  same,
+  forwardPropsMapper,
+} from './util';
+
+const layouts = {
+  "basic": BasicLayout,
+  "default": BasicLayout,
+};
+
+/**
+ * Pick the selected layout and forwards all properties to it.
+ */
+class MSALayouter extends PureComponent {
+
+  constructor(props) {
+    super(props);
+    this.el = createRef();
+    this.forwardedPropsKeys = Object.keys(this.constructor.propsToForward);
+  }
+
+  // all properties that should be forwarded
+  static propsToForward = {
+    // List of props forwarded to the SequenceViewer component
+    sequenceViewerProps: {
+      "showModBar": same,
+      "onResidueMouseEnter": same,
+      "onResidueMouseLeave": same,
+      "onResidueClick": same,
+      "onResidueDoubleClick": same,
+      "sequenceBorder": "border",
+      "sequenceBorderColor": "borderColor",
+      "sequenceBorderWidth": "borderWidth",
+      "sequenceTextColor": "textColor",
+      "sequenceTextFont": "textFont",
+      "sequenceOverflow": "overflow",
+      "sequenceOverflowX": "overflowX",
+      "sequenceOverflowy": "overflowY",
+      "sequenceScrollBarPositionX": "scrollBarPositionX",
+      "sequenceScrollBarPositionY": "scrollBarPositionY",
+    },
+    // List of props forwarded to the Labels component
+    labelsProps: {
+      "labelComponent": same,
+      "labelStyle": same,
+      "labelAttributes": same,
+    },
+    // List of props forwarded to the PositionBar component
+    positionBarProps: {
+      "markerComponent": same,
+      "markerStyle": same,
+      "markerAttributes": same,
+    },
+    // List of props forwarded to the OverviewBar component
+    overviewBarProps: {
+      "barComponent": same,
+      "barStyle": same,
+      "barAttributes": same,
+    }
+  };
+
+  // behave like a DOM node and support event dispatching
+  dispatchEvent(event) {
+    this.el.current.dispatchEvent(event);
+  }
+
+  render() {
+    const {layout, ...otherProps} = this.props;
+    if (layout in layouts) {
+      const Layout = layouts[layout];
+      const {forwardProps, otherProps: propsOnDiv} =
+        forwardPropsMapper(otherProps, this.constructor.propsToForward);
+      return <div el={this.ref} {...propsOnDiv} >
+          <Layout {...forwardProps} forwardedPropsKeys={this.forwardedPropsKeys} />
+        </div>;
+    } else {
+        console.error(`$this.props.layout} is invalid. Please use one of ${Object.keys(layouts)}`);
+    }
+  }
+}
+
+MSALayouter.defaultProps = {
+  layout: "default"
+};
+
+MSALayouter.propTyes = {
+  /**
+   * Layout scheme to use.
+   */
+  layout: PropTypes.oneOf(Object.keys(layouts)),
+};
+
+export default MSALayouter;

--- a/src/components/layouts/PureBaseLayout.js
+++ b/src/components/layouts/PureBaseLayout.js
@@ -1,0 +1,34 @@
+/**
+* Copyright 2018, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+import { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import {
+  some,
+} from 'lodash';
+
+import shallowEqual from '../../utils/shallowEqual';
+
+/**
+ * Provides a `shouldComponentUpdate` method for the layouts.
+ * Analogous to React.PureComponent, but checks the forwarded properties
+ * shallowly too.
+ */
+class PureBaseLayout extends Component {
+  shouldComponentUpdate(nextProps) {
+    return !(shallowEqual(this.props, nextProps) &&
+      some(this.props.forwardedPropsKeys.map(k => shallowEqual(this.props[k], nextProps[k]))));
+  }
+}
+
+PureBaseLayout.propTypes = {
+  forwardPropKeys: PropTypes.array,
+};
+
+export default PureBaseLayout;

--- a/src/components/layouts/__snapshots__/basic.test.js.snap
+++ b/src/components/layouts/__snapshots__/basic.test.js.snap
@@ -2,9 +2,7 @@
 
 exports[`renders without crashing 1`] = `
 <PropsToReduxComponent
-  backgroundColor="red"
   colorScheme="clustal"
-  engine="canvas"
   height={100}
   layout="basic"
   sequences={
@@ -44,6 +42,7 @@ exports[`renders without crashing 1`] = `
   width={500}
 >
   <MSAViewerComponent
+    layout="basic"
     msaStore={
       Object {
         "dispatch": [Function],
@@ -67,7 +66,8 @@ exports[`renders without crashing 1`] = `
     >
       <div>
         <MSALayouter
-          layout="default"
+          layout="basic"
+          onResidueClick={[Function]}
         >
           <div>
             <Connect(MSABasicLayout)

--- a/src/components/layouts/__snapshots__/basic.test.js.snap
+++ b/src/components/layouts/__snapshots__/basic.test.js.snap
@@ -1,0 +1,2583 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders without crashing 1`] = `
+<PropsToReduxComponent
+  backgroundColor="red"
+  colorScheme="clustal"
+  engine="canvas"
+  height={100}
+  layout="basic"
+  sequences={
+    Array [
+      Object {
+        "name": "sequence 1",
+        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+      },
+      Object {
+        "name": "sequence 2",
+        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+      },
+      Object {
+        "name": "sequence 3",
+        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+      },
+      Object {
+        "name": "sequence 4",
+        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+      },
+      Object {
+        "name": "sequence 5",
+        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+      },
+      Object {
+        "name": "sequence 6",
+        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+      },
+      Object {
+        "name": "sequence 7",
+        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+      },
+    ]
+  }
+  tileHeight={20}
+  tileWidth={20}
+  width={500}
+>
+  <MSAViewerComponent
+    msaStore={
+      Object {
+        "dispatch": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+        Symbol(observable): [Function],
+      }
+    }
+  >
+    <Provider
+      store={
+        Object {
+          "dispatch": [Function],
+          "getState": [Function],
+          "replaceReducer": [Function],
+          "subscribe": [Function],
+          Symbol(observable): [Function],
+        }
+      }
+    >
+      <div>
+        <MSALayouter
+          layout="default"
+        >
+          <div>
+            <Connect(MSABasicLayout)
+              forwardedPropsKeys={
+                Array [
+                  "sequenceViewerProps",
+                  "labelsProps",
+                  "positionBarProps",
+                  "overviewBarProps",
+                ]
+              }
+            >
+              <MSABasicLayout
+                dispatch={[Function]}
+                forwardedPropsKeys={
+                  Array [
+                    "sequenceViewerProps",
+                    "labelsProps",
+                    "positionBarProps",
+                    "overviewBarProps",
+                  ]
+                }
+                tileHeight={20}
+              >
+                <div
+                  style={
+                    Object {
+                      "display": "flex",
+                    }
+                  }
+                >
+                  <Connect(HTMLLabelsComponent)
+                    style={
+                      Object {
+                        "paddingTop": 70,
+                      }
+                    }
+                  >
+                    <HTMLLabelsComponent
+                      cacheElements={10}
+                      dispatch={[Function]}
+                      height={100}
+                      labelStyle={Object {}}
+                      nrYTiles={6}
+                      sequences={
+                        Array [
+                          Object {
+                            "name": "sequence 1",
+                            "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                          },
+                          Object {
+                            "name": "sequence 2",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 3",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 4",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 5",
+                            "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 6",
+                            "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 7",
+                            "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                          },
+                        ]
+                      }
+                      style={
+                        Object {
+                          "paddingTop": 70,
+                        }
+                      }
+                      tileHeight={20}
+                    >
+                      <withPosition(YBarComponent)
+                        cacheElements={10}
+                        componentCache={[Function]}
+                        height={100}
+                        nrYTiles={6}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        style={
+                          Object {
+                            "paddingTop": 70,
+                          }
+                        }
+                        tileComponent={[Function]}
+                        tileHeight={20}
+                      >
+                        <YBarComponent
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          height={100}
+                          nrYTiles={6}
+                          position={
+                            Object {
+                              "currentViewSequence": 0,
+                              "currentViewSequencePosition": 0,
+                              "lastCurrentViewSequence": 0,
+                              "lastStartYTile": 0,
+                              "xPos": 0,
+                              "xPosOffset": -0,
+                              "yPos": 0,
+                              "yPosOffset": -0,
+                            }
+                          }
+                          positionDispatch={[Function]}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          style={
+                            Object {
+                              "paddingTop": 70,
+                            }
+                          }
+                          tileComponent={[Function]}
+                          tileHeight={20}
+                        >
+                          <div
+                            style={
+                              Object {
+                                "paddingTop": 70,
+                              }
+                            }
+                          >
+                            <div
+                              style={
+                                Object {
+                                  "height": 100,
+                                  "overflow": "hidden",
+                                  "position": "relative",
+                                  "whiteSpace": "nowrap",
+                                }
+                              }
+                            >
+                              <ListComponent
+                                componentCache={[Function]}
+                                endTile={7}
+                                startTile={0}
+                                tileComponent={[Function]}
+                              >
+                                <div>
+                                  <Label
+                                    index={0}
+                                    key="0"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 1
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={1}
+                                    key="1"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 2
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={2}
+                                    key="2"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 3
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={3}
+                                    key="3"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 4
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={4}
+                                    key="4"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 5
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={5}
+                                    key="5"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 6
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={6}
+                                    key="6"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 7
+                                    </div>
+                                  </Label>
+                                </div>
+                              </ListComponent>
+                            </div>
+                          </div>
+                        </YBarComponent>
+                      </withPosition(YBarComponent)>
+                    </HTMLLabelsComponent>
+                  </Connect(HTMLLabelsComponent)>
+                  <div>
+                    <Connect(HTMLOverviewBarComponent)
+                      height={50}
+                    >
+                      <HTMLOverviewBarComponent
+                        cacheElements={10}
+                        dispatch={[Function]}
+                        fillColor="#999999"
+                        height={50}
+                        maxLength={60}
+                        method="conservation"
+                        nrXTiles={26}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        tileWidth={20}
+                        width={500}
+                      >
+                        <withPosition(XBarComponent)
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          maxLength={60}
+                          nrXTiles={26}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          tileComponent={[Function]}
+                          tileWidth={20}
+                          width={500}
+                        >
+                          <XBarComponent
+                            cacheElements={10}
+                            componentCache={[Function]}
+                            maxLength={60}
+                            nrXTiles={26}
+                            position={
+                              Object {
+                                "currentViewSequence": 0,
+                                "currentViewSequencePosition": 0,
+                                "lastCurrentViewSequencePosition": 0,
+                                "lastStartXTile": 0,
+                                "xPos": 0,
+                                "xPosOffset": -0,
+                                "yPos": 0,
+                                "yPosOffset": -0,
+                              }
+                            }
+                            positionDispatch={[Function]}
+                            sequences={
+                              Array [
+                                Object {
+                                  "name": "sequence 1",
+                                  "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                },
+                                Object {
+                                  "name": "sequence 2",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 3",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 4",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 5",
+                                  "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 6",
+                                  "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 7",
+                                  "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                },
+                              ]
+                            }
+                            tileComponent={[Function]}
+                            tileWidth={20}
+                            width={500}
+                          >
+                            <div
+                              style={
+                                Object {
+                                  "height": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                style={
+                                  Object {
+                                    "overflow": "hidden",
+                                    "position": "relative",
+                                    "whiteSpace": "nowrap",
+                                    "width": 500,
+                                  }
+                                }
+                              >
+                                <ListComponent
+                                  componentCache={[Function]}
+                                  endTile={46}
+                                  maxWidth={900}
+                                  sequences={
+                                    Array [
+                                      Object {
+                                        "name": "sequence 1",
+                                        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                      },
+                                      Object {
+                                        "name": "sequence 2",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 3",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 4",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 5",
+                                        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 6",
+                                        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 7",
+                                        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                      },
+                                    ]
+                                  }
+                                  startTile={0}
+                                  tileComponent={[Function]}
+                                  tileWidth={20}
+                                >
+                                  <div>
+                                    <Bar
+                                      index={0}
+                                      key="0"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={1}
+                                      key="1"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={2}
+                                      key="2"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={3}
+                                      key="3"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={4}
+                                      key="4"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={5}
+                                      key="5"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 34,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={6}
+                                      key="6"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={7}
+                                      key="7"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 32,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={8}
+                                      key="8"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={9}
+                                      key="9"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={10}
+                                      key="10"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 28,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={11}
+                                      key="11"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 21,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={12}
+                                      key="12"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={13}
+                                      key="13"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={14}
+                                      key="14"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={15}
+                                      key="15"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={16}
+                                      key="16"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={17}
+                                      key="17"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={18}
+                                      key="18"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={19}
+                                      key="19"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={20}
+                                      key="20"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={21}
+                                      key="21"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={22}
+                                      key="22"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={23}
+                                      key="23"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={24}
+                                      key="24"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={25}
+                                      key="25"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={26}
+                                      key="26"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={27}
+                                      key="27"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={28}
+                                      key="28"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={29}
+                                      key="29"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={30}
+                                      key="30"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={31}
+                                      key="31"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={32}
+                                      key="32"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={33}
+                                      key="33"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={34}
+                                      key="34"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={35}
+                                      key="35"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={36}
+                                      key="36"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={37}
+                                      key="37"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={38}
+                                      key="38"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={39}
+                                      key="39"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={40}
+                                      key="40"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={41}
+                                      key="41"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={42}
+                                      key="42"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={43}
+                                      key="43"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={44}
+                                      key="44"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={45}
+                                      key="45"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                  </div>
+                                </ListComponent>
+                              </div>
+                            </div>
+                          </XBarComponent>
+                        </withPosition(XBarComponent)>
+                      </HTMLOverviewBarComponent>
+                    </Connect(HTMLOverviewBarComponent)>
+                    <Connect(HTMLPositionBarComponent)>
+                      <HTMLPositionBarComponent
+                        cacheElements={10}
+                        dispatch={[Function]}
+                        height={15}
+                        markerSteps={2}
+                        markerStyle={Object {}}
+                        maxLength={60}
+                        nrXTiles={26}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        startIndex={1}
+                        style={
+                          Object {
+                            "font": "12px Arial",
+                          }
+                        }
+                        tileWidth={20}
+                        width={500}
+                      >
+                        <withPosition(XBarComponent)
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          height={15}
+                          maxLength={60}
+                          nrXTiles={26}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          style={
+                            Object {
+                              "font": "12px Arial",
+                            }
+                          }
+                          tileComponent={[Function]}
+                          tileWidth={20}
+                          width={500}
+                        >
+                          <XBarComponent
+                            cacheElements={10}
+                            componentCache={[Function]}
+                            height={15}
+                            maxLength={60}
+                            nrXTiles={26}
+                            position={
+                              Object {
+                                "currentViewSequence": 0,
+                                "currentViewSequencePosition": 0,
+                                "lastCurrentViewSequencePosition": 0,
+                                "lastStartXTile": 0,
+                                "xPos": 0,
+                                "xPosOffset": -0,
+                                "yPos": 0,
+                                "yPosOffset": -0,
+                              }
+                            }
+                            positionDispatch={[Function]}
+                            sequences={
+                              Array [
+                                Object {
+                                  "name": "sequence 1",
+                                  "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                },
+                                Object {
+                                  "name": "sequence 2",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 3",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 4",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 5",
+                                  "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 6",
+                                  "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 7",
+                                  "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                },
+                              ]
+                            }
+                            style={
+                              Object {
+                                "font": "12px Arial",
+                              }
+                            }
+                            tileComponent={[Function]}
+                            tileWidth={20}
+                            width={500}
+                          >
+                            <div
+                              height={15}
+                              style={
+                                Object {
+                                  "font": "12px Arial",
+                                }
+                              }
+                            >
+                              <div
+                                style={
+                                  Object {
+                                    "overflow": "hidden",
+                                    "position": "relative",
+                                    "whiteSpace": "nowrap",
+                                    "width": 500,
+                                  }
+                                }
+                              >
+                                <ListComponent
+                                  componentCache={[Function]}
+                                  endTile={46}
+                                  maxWidth={900}
+                                  sequences={
+                                    Array [
+                                      Object {
+                                        "name": "sequence 1",
+                                        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                      },
+                                      Object {
+                                        "name": "sequence 2",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 3",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 4",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 5",
+                                        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 6",
+                                        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 7",
+                                        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                      },
+                                    ]
+                                  }
+                                  startTile={0}
+                                  tileComponent={[Function]}
+                                  tileWidth={20}
+                                >
+                                  <div>
+                                    <Marker
+                                      index={0}
+                                      key="0"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        1
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={1}
+                                      key="1"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={2}
+                                      key="2"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        3
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={3}
+                                      key="3"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={4}
+                                      key="4"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        5
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={5}
+                                      key="5"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={6}
+                                      key="6"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        7
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={7}
+                                      key="7"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={8}
+                                      key="8"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        9
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={9}
+                                      key="9"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={10}
+                                      key="10"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        11
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={11}
+                                      key="11"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={12}
+                                      key="12"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        13
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={13}
+                                      key="13"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={14}
+                                      key="14"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        15
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={15}
+                                      key="15"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={16}
+                                      key="16"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        17
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={17}
+                                      key="17"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={18}
+                                      key="18"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        19
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={19}
+                                      key="19"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={20}
+                                      key="20"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        21
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={21}
+                                      key="21"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={22}
+                                      key="22"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        23
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={23}
+                                      key="23"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={24}
+                                      key="24"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        25
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={25}
+                                      key="25"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={26}
+                                      key="26"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        27
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={27}
+                                      key="27"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={28}
+                                      key="28"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        29
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={29}
+                                      key="29"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={30}
+                                      key="30"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        31
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={31}
+                                      key="31"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={32}
+                                      key="32"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        33
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={33}
+                                      key="33"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={34}
+                                      key="34"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        35
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={35}
+                                      key="35"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={36}
+                                      key="36"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        37
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={37}
+                                      key="37"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={38}
+                                      key="38"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        39
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={39}
+                                      key="39"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={40}
+                                      key="40"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        41
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={41}
+                                      key="41"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={42}
+                                      key="42"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        43
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={43}
+                                      key="43"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={44}
+                                      key="44"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        45
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={45}
+                                      key="45"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                  </div>
+                                </ListComponent>
+                              </div>
+                            </div>
+                          </XBarComponent>
+                        </withPosition(XBarComponent)>
+                      </HTMLPositionBarComponent>
+                    </Connect(HTMLPositionBarComponent)>
+                    <Connect(withPosition(SequenceViewerComponent))>
+                      <withPosition(SequenceViewerComponent)
+                        colorScheme={
+                          ColorScheme {
+                            "scheme": StaticSchemeClass {
+                              "defaultColor": "#ffffff",
+                              "getColor": [Function],
+                              "map": Object {
+                                "A": "orange",
+                                "B": "#fff",
+                                "C": "green",
+                                "D": "red",
+                                "E": "red",
+                                "F": "blue",
+                                "G": "orange",
+                                "Gap": "#fff",
+                                "H": "red",
+                                "I": "green",
+                                "J": "#fff",
+                                "K": "red",
+                                "L": "green",
+                                "M": "green",
+                                "N": "#fff",
+                                "O": "#fff",
+                                "P": "orange",
+                                "Q": "#fff",
+                                "R": "red",
+                                "S": "orange",
+                                "T": "orange",
+                                "U": "#fff",
+                                "V": "green",
+                                "W": "blue",
+                                "X": "#fff",
+                                "Y": "blue",
+                                "Z": "#fff",
+                              },
+                              "type": "static",
+                            },
+                          }
+                        }
+                        dispatch={[Function]}
+                        fullHeight={140}
+                        fullWidth={1200}
+                        height={100}
+                        nrXTiles={26}
+                        nrYTiles={6}
+                        sequences={
+                          Object {
+                            "length": 7,
+                            "maxLength": 60,
+                            "raw": Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ],
+                          }
+                        }
+                        tileHeight={20}
+                        tileWidth={20}
+                        width={500}
+                      >
+                        <SequenceViewerComponent
+                          border={false}
+                          borderColor="black"
+                          borderWidth={1}
+                          cacheElements={20}
+                          colorScheme={
+                            ColorScheme {
+                              "scheme": StaticSchemeClass {
+                                "defaultColor": "#ffffff",
+                                "getColor": [Function],
+                                "map": Object {
+                                  "A": "orange",
+                                  "B": "#fff",
+                                  "C": "green",
+                                  "D": "red",
+                                  "E": "red",
+                                  "F": "blue",
+                                  "G": "orange",
+                                  "Gap": "#fff",
+                                  "H": "red",
+                                  "I": "green",
+                                  "J": "#fff",
+                                  "K": "red",
+                                  "L": "green",
+                                  "M": "green",
+                                  "N": "#fff",
+                                  "O": "#fff",
+                                  "P": "orange",
+                                  "Q": "#fff",
+                                  "R": "red",
+                                  "S": "orange",
+                                  "T": "orange",
+                                  "U": "#fff",
+                                  "V": "green",
+                                  "W": "blue",
+                                  "X": "#fff",
+                                  "Y": "blue",
+                                  "Z": "#fff",
+                                },
+                                "type": "static",
+                              },
+                            }
+                          }
+                          dispatch={[Function]}
+                          fullHeight={140}
+                          fullWidth={1200}
+                          height={100}
+                          nrXTiles={26}
+                          nrYTiles={6}
+                          overflow="hidden"
+                          overflowX="auto"
+                          overflowY="auto"
+                          position={
+                            Object {
+                              "currentViewSequence": 0,
+                              "currentViewSequencePosition": 0,
+                              "xPos": 0,
+                              "xPosOffset": -0,
+                              "yPos": 0,
+                              "yPosOffset": -0,
+                            }
+                          }
+                          positionDispatch={[Function]}
+                          scrollBarPositionX="bottom"
+                          scrollBarPositionY="right"
+                          sequences={
+                            Object {
+                              "length": 7,
+                              "maxLength": 60,
+                              "raw": Array [
+                                Object {
+                                  "name": "sequence 1",
+                                  "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                },
+                                Object {
+                                  "name": "sequence 2",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 3",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 4",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 5",
+                                  "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 6",
+                                  "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 7",
+                                  "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                },
+                              ],
+                            }
+                          }
+                          showModBar={false}
+                          textColor="black"
+                          textFont="18px Arial"
+                          tileHeight={20}
+                          tileWidth={20}
+                          width={500}
+                          xGridSize={10}
+                          yGridSize={10}
+                        >
+                          <div
+                            height={100}
+                            style={
+                              Object {
+                                "cursor": "grab",
+                                "height": 100,
+                                "position": "relative",
+                                "width": 500,
+                              }
+                            }
+                            width={500}
+                          >
+                            <canvas
+                              height={100}
+                              style={
+                                Object {
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "top": 0,
+                                }
+                              }
+                              width={500}
+                            >
+                              Your browser does not seem to support HTML5 canvas.
+                            </canvas>
+                            <canvas
+                              height={100}
+                              style={
+                                Object {
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "top": 0,
+                                }
+                              }
+                              width={500}
+                            >
+                              Your browser does not seem to support HTML5 canvas.
+                            </canvas>
+                            <withPosition(FakeScroll)
+                              fullHeight={140}
+                              fullWidth={1200}
+                              height={100}
+                              overflow="hidden"
+                              overflowX="auto"
+                              overflowY="auto"
+                              positionX="bottom"
+                              positionY="right"
+                              width={500}
+                            >
+                              <FakeScroll
+                                fullHeight={140}
+                                fullWidth={1200}
+                                height={100}
+                                overflow="hidden"
+                                overflowX="auto"
+                                overflowY="auto"
+                                position={
+                                  Object {
+                                    "currentViewSequence": 0,
+                                    "currentViewSequencePosition": 0,
+                                    "xPos": 0,
+                                    "xPosOffset": -0,
+                                    "yPos": 0,
+                                    "yPosOffset": -0,
+                                  }
+                                }
+                                positionDispatch={[Function]}
+                                positionX="bottom"
+                                positionY="right"
+                                scrollBarWidth={5}
+                                width={500}
+                              >
+                                <div />
+                              </FakeScroll>
+                            </withPosition(FakeScroll)>
+                          </div>
+                        </SequenceViewerComponent>
+                      </withPosition(SequenceViewerComponent)>
+                    </Connect(withPosition(SequenceViewerComponent))>
+                    <div
+                      style={
+                        Object {
+                          "height": 10,
+                        }
+                      }
+                    />
+                  </div>
+                </div>
+              </MSABasicLayout>
+            </Connect(MSABasicLayout)>
+          </div>
+        </MSALayouter>
+      </div>
+    </Provider>
+  </MSAViewerComponent>
+</PropsToReduxComponent>
+`;

--- a/src/components/layouts/__snapshots__/compact.test.js.snap
+++ b/src/components/layouts/__snapshots__/compact.test.js.snap
@@ -1,0 +1,2583 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders without crashing 1`] = `
+<PropsToReduxComponent
+  backgroundColor="red"
+  colorScheme="clustal"
+  engine="canvas"
+  height={100}
+  layout="compact"
+  sequences={
+    Array [
+      Object {
+        "name": "sequence 1",
+        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+      },
+      Object {
+        "name": "sequence 2",
+        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+      },
+      Object {
+        "name": "sequence 3",
+        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+      },
+      Object {
+        "name": "sequence 4",
+        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+      },
+      Object {
+        "name": "sequence 5",
+        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+      },
+      Object {
+        "name": "sequence 6",
+        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+      },
+      Object {
+        "name": "sequence 7",
+        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+      },
+    ]
+  }
+  tileHeight={20}
+  tileWidth={20}
+  width={500}
+>
+  <MSAViewerComponent
+    msaStore={
+      Object {
+        "dispatch": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+        Symbol(observable): [Function],
+      }
+    }
+  >
+    <Provider
+      store={
+        Object {
+          "dispatch": [Function],
+          "getState": [Function],
+          "replaceReducer": [Function],
+          "subscribe": [Function],
+          Symbol(observable): [Function],
+        }
+      }
+    >
+      <div>
+        <MSALayouter
+          layout="default"
+        >
+          <div>
+            <Connect(MSABasicLayout)
+              forwardedPropsKeys={
+                Array [
+                  "sequenceViewerProps",
+                  "labelsProps",
+                  "positionBarProps",
+                  "overviewBarProps",
+                ]
+              }
+            >
+              <MSABasicLayout
+                dispatch={[Function]}
+                forwardedPropsKeys={
+                  Array [
+                    "sequenceViewerProps",
+                    "labelsProps",
+                    "positionBarProps",
+                    "overviewBarProps",
+                  ]
+                }
+                tileHeight={20}
+              >
+                <div
+                  style={
+                    Object {
+                      "display": "flex",
+                    }
+                  }
+                >
+                  <Connect(HTMLLabelsComponent)
+                    style={
+                      Object {
+                        "paddingTop": 70,
+                      }
+                    }
+                  >
+                    <HTMLLabelsComponent
+                      cacheElements={10}
+                      dispatch={[Function]}
+                      height={100}
+                      labelStyle={Object {}}
+                      nrYTiles={6}
+                      sequences={
+                        Array [
+                          Object {
+                            "name": "sequence 1",
+                            "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                          },
+                          Object {
+                            "name": "sequence 2",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 3",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 4",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 5",
+                            "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 6",
+                            "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 7",
+                            "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                          },
+                        ]
+                      }
+                      style={
+                        Object {
+                          "paddingTop": 70,
+                        }
+                      }
+                      tileHeight={20}
+                    >
+                      <withPosition(YBarComponent)
+                        cacheElements={10}
+                        componentCache={[Function]}
+                        height={100}
+                        nrYTiles={6}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        style={
+                          Object {
+                            "paddingTop": 70,
+                          }
+                        }
+                        tileComponent={[Function]}
+                        tileHeight={20}
+                      >
+                        <YBarComponent
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          height={100}
+                          nrYTiles={6}
+                          position={
+                            Object {
+                              "currentViewSequence": 0,
+                              "currentViewSequencePosition": 0,
+                              "lastCurrentViewSequence": 0,
+                              "lastStartYTile": 0,
+                              "xPos": 0,
+                              "xPosOffset": -0,
+                              "yPos": 0,
+                              "yPosOffset": -0,
+                            }
+                          }
+                          positionDispatch={[Function]}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          style={
+                            Object {
+                              "paddingTop": 70,
+                            }
+                          }
+                          tileComponent={[Function]}
+                          tileHeight={20}
+                        >
+                          <div
+                            style={
+                              Object {
+                                "paddingTop": 70,
+                              }
+                            }
+                          >
+                            <div
+                              style={
+                                Object {
+                                  "height": 100,
+                                  "overflow": "hidden",
+                                  "position": "relative",
+                                  "whiteSpace": "nowrap",
+                                }
+                              }
+                            >
+                              <ListComponent
+                                componentCache={[Function]}
+                                endTile={7}
+                                startTile={0}
+                                tileComponent={[Function]}
+                              >
+                                <div>
+                                  <Label
+                                    index={0}
+                                    key="0"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 1
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={1}
+                                    key="1"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 2
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={2}
+                                    key="2"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 3
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={3}
+                                    key="3"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 4
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={4}
+                                    key="4"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 5
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={5}
+                                    key="5"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 6
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={6}
+                                    key="6"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 7
+                                    </div>
+                                  </Label>
+                                </div>
+                              </ListComponent>
+                            </div>
+                          </div>
+                        </YBarComponent>
+                      </withPosition(YBarComponent)>
+                    </HTMLLabelsComponent>
+                  </Connect(HTMLLabelsComponent)>
+                  <div>
+                    <Connect(HTMLOverviewBarComponent)
+                      height={50}
+                    >
+                      <HTMLOverviewBarComponent
+                        cacheElements={10}
+                        dispatch={[Function]}
+                        fillColor="#999999"
+                        height={50}
+                        maxLength={60}
+                        method="conservation"
+                        nrXTiles={26}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        tileWidth={20}
+                        width={500}
+                      >
+                        <withPosition(XBarComponent)
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          maxLength={60}
+                          nrXTiles={26}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          tileComponent={[Function]}
+                          tileWidth={20}
+                          width={500}
+                        >
+                          <XBarComponent
+                            cacheElements={10}
+                            componentCache={[Function]}
+                            maxLength={60}
+                            nrXTiles={26}
+                            position={
+                              Object {
+                                "currentViewSequence": 0,
+                                "currentViewSequencePosition": 0,
+                                "lastCurrentViewSequencePosition": 0,
+                                "lastStartXTile": 0,
+                                "xPos": 0,
+                                "xPosOffset": -0,
+                                "yPos": 0,
+                                "yPosOffset": -0,
+                              }
+                            }
+                            positionDispatch={[Function]}
+                            sequences={
+                              Array [
+                                Object {
+                                  "name": "sequence 1",
+                                  "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                },
+                                Object {
+                                  "name": "sequence 2",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 3",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 4",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 5",
+                                  "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 6",
+                                  "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 7",
+                                  "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                },
+                              ]
+                            }
+                            tileComponent={[Function]}
+                            tileWidth={20}
+                            width={500}
+                          >
+                            <div
+                              style={
+                                Object {
+                                  "height": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                style={
+                                  Object {
+                                    "overflow": "hidden",
+                                    "position": "relative",
+                                    "whiteSpace": "nowrap",
+                                    "width": 500,
+                                  }
+                                }
+                              >
+                                <ListComponent
+                                  componentCache={[Function]}
+                                  endTile={46}
+                                  maxWidth={900}
+                                  sequences={
+                                    Array [
+                                      Object {
+                                        "name": "sequence 1",
+                                        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                      },
+                                      Object {
+                                        "name": "sequence 2",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 3",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 4",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 5",
+                                        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 6",
+                                        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 7",
+                                        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                      },
+                                    ]
+                                  }
+                                  startTile={0}
+                                  tileComponent={[Function]}
+                                  tileWidth={20}
+                                >
+                                  <div>
+                                    <Bar
+                                      index={0}
+                                      key="0"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={1}
+                                      key="1"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={2}
+                                      key="2"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={3}
+                                      key="3"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={4}
+                                      key="4"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={5}
+                                      key="5"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 34,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={6}
+                                      key="6"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={7}
+                                      key="7"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 32,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={8}
+                                      key="8"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={9}
+                                      key="9"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={10}
+                                      key="10"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 28,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={11}
+                                      key="11"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 21,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={12}
+                                      key="12"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={13}
+                                      key="13"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={14}
+                                      key="14"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={15}
+                                      key="15"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={16}
+                                      key="16"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={17}
+                                      key="17"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={18}
+                                      key="18"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={19}
+                                      key="19"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={20}
+                                      key="20"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={21}
+                                      key="21"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={22}
+                                      key="22"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={23}
+                                      key="23"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={24}
+                                      key="24"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={25}
+                                      key="25"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={26}
+                                      key="26"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={27}
+                                      key="27"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={28}
+                                      key="28"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={29}
+                                      key="29"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={30}
+                                      key="30"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={31}
+                                      key="31"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={32}
+                                      key="32"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={33}
+                                      key="33"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={34}
+                                      key="34"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={35}
+                                      key="35"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={36}
+                                      key="36"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={37}
+                                      key="37"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={38}
+                                      key="38"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={39}
+                                      key="39"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={40}
+                                      key="40"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={41}
+                                      key="41"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={42}
+                                      key="42"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={43}
+                                      key="43"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={44}
+                                      key="44"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={45}
+                                      key="45"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                  </div>
+                                </ListComponent>
+                              </div>
+                            </div>
+                          </XBarComponent>
+                        </withPosition(XBarComponent)>
+                      </HTMLOverviewBarComponent>
+                    </Connect(HTMLOverviewBarComponent)>
+                    <Connect(HTMLPositionBarComponent)>
+                      <HTMLPositionBarComponent
+                        cacheElements={10}
+                        dispatch={[Function]}
+                        height={15}
+                        markerSteps={2}
+                        markerStyle={Object {}}
+                        maxLength={60}
+                        nrXTiles={26}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        startIndex={1}
+                        style={
+                          Object {
+                            "font": "12px Arial",
+                          }
+                        }
+                        tileWidth={20}
+                        width={500}
+                      >
+                        <withPosition(XBarComponent)
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          height={15}
+                          maxLength={60}
+                          nrXTiles={26}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          style={
+                            Object {
+                              "font": "12px Arial",
+                            }
+                          }
+                          tileComponent={[Function]}
+                          tileWidth={20}
+                          width={500}
+                        >
+                          <XBarComponent
+                            cacheElements={10}
+                            componentCache={[Function]}
+                            height={15}
+                            maxLength={60}
+                            nrXTiles={26}
+                            position={
+                              Object {
+                                "currentViewSequence": 0,
+                                "currentViewSequencePosition": 0,
+                                "lastCurrentViewSequencePosition": 0,
+                                "lastStartXTile": 0,
+                                "xPos": 0,
+                                "xPosOffset": -0,
+                                "yPos": 0,
+                                "yPosOffset": -0,
+                              }
+                            }
+                            positionDispatch={[Function]}
+                            sequences={
+                              Array [
+                                Object {
+                                  "name": "sequence 1",
+                                  "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                },
+                                Object {
+                                  "name": "sequence 2",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 3",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 4",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 5",
+                                  "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 6",
+                                  "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 7",
+                                  "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                },
+                              ]
+                            }
+                            style={
+                              Object {
+                                "font": "12px Arial",
+                              }
+                            }
+                            tileComponent={[Function]}
+                            tileWidth={20}
+                            width={500}
+                          >
+                            <div
+                              height={15}
+                              style={
+                                Object {
+                                  "font": "12px Arial",
+                                }
+                              }
+                            >
+                              <div
+                                style={
+                                  Object {
+                                    "overflow": "hidden",
+                                    "position": "relative",
+                                    "whiteSpace": "nowrap",
+                                    "width": 500,
+                                  }
+                                }
+                              >
+                                <ListComponent
+                                  componentCache={[Function]}
+                                  endTile={46}
+                                  maxWidth={900}
+                                  sequences={
+                                    Array [
+                                      Object {
+                                        "name": "sequence 1",
+                                        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                      },
+                                      Object {
+                                        "name": "sequence 2",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 3",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 4",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 5",
+                                        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 6",
+                                        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 7",
+                                        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                      },
+                                    ]
+                                  }
+                                  startTile={0}
+                                  tileComponent={[Function]}
+                                  tileWidth={20}
+                                >
+                                  <div>
+                                    <Marker
+                                      index={0}
+                                      key="0"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        1
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={1}
+                                      key="1"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={2}
+                                      key="2"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        3
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={3}
+                                      key="3"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={4}
+                                      key="4"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        5
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={5}
+                                      key="5"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={6}
+                                      key="6"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        7
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={7}
+                                      key="7"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={8}
+                                      key="8"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        9
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={9}
+                                      key="9"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={10}
+                                      key="10"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        11
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={11}
+                                      key="11"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={12}
+                                      key="12"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        13
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={13}
+                                      key="13"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={14}
+                                      key="14"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        15
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={15}
+                                      key="15"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={16}
+                                      key="16"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        17
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={17}
+                                      key="17"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={18}
+                                      key="18"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        19
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={19}
+                                      key="19"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={20}
+                                      key="20"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        21
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={21}
+                                      key="21"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={22}
+                                      key="22"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        23
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={23}
+                                      key="23"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={24}
+                                      key="24"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        25
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={25}
+                                      key="25"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={26}
+                                      key="26"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        27
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={27}
+                                      key="27"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={28}
+                                      key="28"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        29
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={29}
+                                      key="29"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={30}
+                                      key="30"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        31
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={31}
+                                      key="31"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={32}
+                                      key="32"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        33
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={33}
+                                      key="33"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={34}
+                                      key="34"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        35
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={35}
+                                      key="35"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={36}
+                                      key="36"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        37
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={37}
+                                      key="37"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={38}
+                                      key="38"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        39
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={39}
+                                      key="39"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={40}
+                                      key="40"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        41
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={41}
+                                      key="41"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={42}
+                                      key="42"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        43
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={43}
+                                      key="43"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={44}
+                                      key="44"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        45
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={45}
+                                      key="45"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                  </div>
+                                </ListComponent>
+                              </div>
+                            </div>
+                          </XBarComponent>
+                        </withPosition(XBarComponent)>
+                      </HTMLPositionBarComponent>
+                    </Connect(HTMLPositionBarComponent)>
+                    <Connect(withPosition(SequenceViewerComponent))>
+                      <withPosition(SequenceViewerComponent)
+                        colorScheme={
+                          ColorScheme {
+                            "scheme": StaticSchemeClass {
+                              "defaultColor": "#ffffff",
+                              "getColor": [Function],
+                              "map": Object {
+                                "A": "orange",
+                                "B": "#fff",
+                                "C": "green",
+                                "D": "red",
+                                "E": "red",
+                                "F": "blue",
+                                "G": "orange",
+                                "Gap": "#fff",
+                                "H": "red",
+                                "I": "green",
+                                "J": "#fff",
+                                "K": "red",
+                                "L": "green",
+                                "M": "green",
+                                "N": "#fff",
+                                "O": "#fff",
+                                "P": "orange",
+                                "Q": "#fff",
+                                "R": "red",
+                                "S": "orange",
+                                "T": "orange",
+                                "U": "#fff",
+                                "V": "green",
+                                "W": "blue",
+                                "X": "#fff",
+                                "Y": "blue",
+                                "Z": "#fff",
+                              },
+                              "type": "static",
+                            },
+                          }
+                        }
+                        dispatch={[Function]}
+                        fullHeight={140}
+                        fullWidth={1200}
+                        height={100}
+                        nrXTiles={26}
+                        nrYTiles={6}
+                        sequences={
+                          Object {
+                            "length": 7,
+                            "maxLength": 60,
+                            "raw": Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ],
+                          }
+                        }
+                        tileHeight={20}
+                        tileWidth={20}
+                        width={500}
+                      >
+                        <SequenceViewerComponent
+                          border={false}
+                          borderColor="black"
+                          borderWidth={1}
+                          cacheElements={20}
+                          colorScheme={
+                            ColorScheme {
+                              "scheme": StaticSchemeClass {
+                                "defaultColor": "#ffffff",
+                                "getColor": [Function],
+                                "map": Object {
+                                  "A": "orange",
+                                  "B": "#fff",
+                                  "C": "green",
+                                  "D": "red",
+                                  "E": "red",
+                                  "F": "blue",
+                                  "G": "orange",
+                                  "Gap": "#fff",
+                                  "H": "red",
+                                  "I": "green",
+                                  "J": "#fff",
+                                  "K": "red",
+                                  "L": "green",
+                                  "M": "green",
+                                  "N": "#fff",
+                                  "O": "#fff",
+                                  "P": "orange",
+                                  "Q": "#fff",
+                                  "R": "red",
+                                  "S": "orange",
+                                  "T": "orange",
+                                  "U": "#fff",
+                                  "V": "green",
+                                  "W": "blue",
+                                  "X": "#fff",
+                                  "Y": "blue",
+                                  "Z": "#fff",
+                                },
+                                "type": "static",
+                              },
+                            }
+                          }
+                          dispatch={[Function]}
+                          fullHeight={140}
+                          fullWidth={1200}
+                          height={100}
+                          nrXTiles={26}
+                          nrYTiles={6}
+                          overflow="hidden"
+                          overflowX="auto"
+                          overflowY="auto"
+                          position={
+                            Object {
+                              "currentViewSequence": 0,
+                              "currentViewSequencePosition": 0,
+                              "xPos": 0,
+                              "xPosOffset": -0,
+                              "yPos": 0,
+                              "yPosOffset": -0,
+                            }
+                          }
+                          positionDispatch={[Function]}
+                          scrollBarPositionX="bottom"
+                          scrollBarPositionY="right"
+                          sequences={
+                            Object {
+                              "length": 7,
+                              "maxLength": 60,
+                              "raw": Array [
+                                Object {
+                                  "name": "sequence 1",
+                                  "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                },
+                                Object {
+                                  "name": "sequence 2",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 3",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 4",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 5",
+                                  "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 6",
+                                  "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 7",
+                                  "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                },
+                              ],
+                            }
+                          }
+                          showModBar={false}
+                          textColor="black"
+                          textFont="18px Arial"
+                          tileHeight={20}
+                          tileWidth={20}
+                          width={500}
+                          xGridSize={10}
+                          yGridSize={10}
+                        >
+                          <div
+                            height={100}
+                            style={
+                              Object {
+                                "cursor": "grab",
+                                "height": 100,
+                                "position": "relative",
+                                "width": 500,
+                              }
+                            }
+                            width={500}
+                          >
+                            <canvas
+                              height={100}
+                              style={
+                                Object {
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "top": 0,
+                                }
+                              }
+                              width={500}
+                            >
+                              Your browser does not seem to support HTML5 canvas.
+                            </canvas>
+                            <canvas
+                              height={100}
+                              style={
+                                Object {
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "top": 0,
+                                }
+                              }
+                              width={500}
+                            >
+                              Your browser does not seem to support HTML5 canvas.
+                            </canvas>
+                            <withPosition(FakeScroll)
+                              fullHeight={140}
+                              fullWidth={1200}
+                              height={100}
+                              overflow="hidden"
+                              overflowX="auto"
+                              overflowY="auto"
+                              positionX="bottom"
+                              positionY="right"
+                              width={500}
+                            >
+                              <FakeScroll
+                                fullHeight={140}
+                                fullWidth={1200}
+                                height={100}
+                                overflow="hidden"
+                                overflowX="auto"
+                                overflowY="auto"
+                                position={
+                                  Object {
+                                    "currentViewSequence": 0,
+                                    "currentViewSequencePosition": 0,
+                                    "xPos": 0,
+                                    "xPosOffset": -0,
+                                    "yPos": 0,
+                                    "yPosOffset": -0,
+                                  }
+                                }
+                                positionDispatch={[Function]}
+                                positionX="bottom"
+                                positionY="right"
+                                scrollBarWidth={5}
+                                width={500}
+                              >
+                                <div />
+                              </FakeScroll>
+                            </withPosition(FakeScroll)>
+                          </div>
+                        </SequenceViewerComponent>
+                      </withPosition(SequenceViewerComponent)>
+                    </Connect(withPosition(SequenceViewerComponent))>
+                    <div
+                      style={
+                        Object {
+                          "height": 10,
+                        }
+                      }
+                    />
+                  </div>
+                </div>
+              </MSABasicLayout>
+            </Connect(MSABasicLayout)>
+          </div>
+        </MSALayouter>
+      </div>
+    </Provider>
+  </MSAViewerComponent>
+</PropsToReduxComponent>
+`;

--- a/src/components/layouts/__snapshots__/compact.test.js.snap
+++ b/src/components/layouts/__snapshots__/compact.test.js.snap
@@ -2,9 +2,7 @@
 
 exports[`renders without crashing 1`] = `
 <PropsToReduxComponent
-  backgroundColor="red"
   colorScheme="clustal"
-  engine="canvas"
   height={100}
   layout="compact"
   sequences={
@@ -44,6 +42,7 @@ exports[`renders without crashing 1`] = `
   width={500}
 >
   <MSAViewerComponent
+    layout="compact"
     msaStore={
       Object {
         "dispatch": [Function],
@@ -67,10 +66,11 @@ exports[`renders without crashing 1`] = `
     >
       <div>
         <MSALayouter
-          layout="default"
+          layout="compact"
+          onResidueClick={[Function]}
         >
           <div>
-            <Connect(MSABasicLayout)
+            <Connect(MSAInverseLayout)
               forwardedPropsKeys={
                 Array [
                   "sequenceViewerProps",
@@ -80,7 +80,7 @@ exports[`renders without crashing 1`] = `
                 ]
               }
             >
-              <MSABasicLayout
+              <MSAInverseLayout
                 dispatch={[Function]}
                 forwardedPropsKeys={
                   Array [
@@ -99,291 +99,6 @@ exports[`renders without crashing 1`] = `
                     }
                   }
                 >
-                  <Connect(HTMLLabelsComponent)
-                    style={
-                      Object {
-                        "paddingTop": 70,
-                      }
-                    }
-                  >
-                    <HTMLLabelsComponent
-                      cacheElements={10}
-                      dispatch={[Function]}
-                      height={100}
-                      labelStyle={Object {}}
-                      nrYTiles={6}
-                      sequences={
-                        Array [
-                          Object {
-                            "name": "sequence 1",
-                            "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                          },
-                          Object {
-                            "name": "sequence 2",
-                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                          },
-                          Object {
-                            "name": "sequence 3",
-                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                          },
-                          Object {
-                            "name": "sequence 4",
-                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                          },
-                          Object {
-                            "name": "sequence 5",
-                            "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                          },
-                          Object {
-                            "name": "sequence 6",
-                            "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                          },
-                          Object {
-                            "name": "sequence 7",
-                            "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                          },
-                        ]
-                      }
-                      style={
-                        Object {
-                          "paddingTop": 70,
-                        }
-                      }
-                      tileHeight={20}
-                    >
-                      <withPosition(YBarComponent)
-                        cacheElements={10}
-                        componentCache={[Function]}
-                        height={100}
-                        nrYTiles={6}
-                        sequences={
-                          Array [
-                            Object {
-                              "name": "sequence 1",
-                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                            },
-                            Object {
-                              "name": "sequence 2",
-                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 3",
-                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 4",
-                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 5",
-                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 6",
-                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 7",
-                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                            },
-                          ]
-                        }
-                        style={
-                          Object {
-                            "paddingTop": 70,
-                          }
-                        }
-                        tileComponent={[Function]}
-                        tileHeight={20}
-                      >
-                        <YBarComponent
-                          cacheElements={10}
-                          componentCache={[Function]}
-                          height={100}
-                          nrYTiles={6}
-                          position={
-                            Object {
-                              "currentViewSequence": 0,
-                              "currentViewSequencePosition": 0,
-                              "lastCurrentViewSequence": 0,
-                              "lastStartYTile": 0,
-                              "xPos": 0,
-                              "xPosOffset": -0,
-                              "yPos": 0,
-                              "yPosOffset": -0,
-                            }
-                          }
-                          positionDispatch={[Function]}
-                          sequences={
-                            Array [
-                              Object {
-                                "name": "sequence 1",
-                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                              },
-                              Object {
-                                "name": "sequence 2",
-                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                              },
-                              Object {
-                                "name": "sequence 3",
-                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                              },
-                              Object {
-                                "name": "sequence 4",
-                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                              },
-                              Object {
-                                "name": "sequence 5",
-                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                              },
-                              Object {
-                                "name": "sequence 6",
-                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                              },
-                              Object {
-                                "name": "sequence 7",
-                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                              },
-                            ]
-                          }
-                          style={
-                            Object {
-                              "paddingTop": 70,
-                            }
-                          }
-                          tileComponent={[Function]}
-                          tileHeight={20}
-                        >
-                          <div
-                            style={
-                              Object {
-                                "paddingTop": 70,
-                              }
-                            }
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "height": 100,
-                                  "overflow": "hidden",
-                                  "position": "relative",
-                                  "whiteSpace": "nowrap",
-                                }
-                              }
-                            >
-                              <ListComponent
-                                componentCache={[Function]}
-                                endTile={7}
-                                startTile={0}
-                                tileComponent={[Function]}
-                              >
-                                <div>
-                                  <Label
-                                    index={0}
-                                    key="0"
-                                  >
-                                    <div
-                                      style={
-                                        Object {
-                                          "height": 20,
-                                        }
-                                      }
-                                    >
-                                      sequence 1
-                                    </div>
-                                  </Label>
-                                  <Label
-                                    index={1}
-                                    key="1"
-                                  >
-                                    <div
-                                      style={
-                                        Object {
-                                          "height": 20,
-                                        }
-                                      }
-                                    >
-                                      sequence 2
-                                    </div>
-                                  </Label>
-                                  <Label
-                                    index={2}
-                                    key="2"
-                                  >
-                                    <div
-                                      style={
-                                        Object {
-                                          "height": 20,
-                                        }
-                                      }
-                                    >
-                                      sequence 3
-                                    </div>
-                                  </Label>
-                                  <Label
-                                    index={3}
-                                    key="3"
-                                  >
-                                    <div
-                                      style={
-                                        Object {
-                                          "height": 20,
-                                        }
-                                      }
-                                    >
-                                      sequence 4
-                                    </div>
-                                  </Label>
-                                  <Label
-                                    index={4}
-                                    key="4"
-                                  >
-                                    <div
-                                      style={
-                                        Object {
-                                          "height": 20,
-                                        }
-                                      }
-                                    >
-                                      sequence 5
-                                    </div>
-                                  </Label>
-                                  <Label
-                                    index={5}
-                                    key="5"
-                                  >
-                                    <div
-                                      style={
-                                        Object {
-                                          "height": 20,
-                                        }
-                                      }
-                                    >
-                                      sequence 6
-                                    </div>
-                                  </Label>
-                                  <Label
-                                    index={6}
-                                    key="6"
-                                  >
-                                    <div
-                                      style={
-                                        Object {
-                                          "height": 20,
-                                        }
-                                      }
-                                    >
-                                      sequence 7
-                                    </div>
-                                  </Label>
-                                </div>
-                              </ListComponent>
-                            </div>
-                          </div>
-                        </YBarComponent>
-                      </withPosition(YBarComponent)>
-                    </HTMLLabelsComponent>
-                  </Connect(HTMLLabelsComponent)>
                   <div>
                     <Connect(HTMLOverviewBarComponent)
                       height={50}
@@ -2563,17 +2278,295 @@ exports[`renders without crashing 1`] = `
                         </SequenceViewerComponent>
                       </withPosition(SequenceViewerComponent)>
                     </Connect(withPosition(SequenceViewerComponent))>
-                    <div
+                  </div>
+                  <Connect(HTMLLabelsComponent)
+                    style={
+                      Object {
+                        "paddingTop": 70,
+                      }
+                    }
+                  >
+                    <HTMLLabelsComponent
+                      cacheElements={10}
+                      dispatch={[Function]}
+                      height={100}
+                      labelStyle={Object {}}
+                      nrYTiles={6}
+                      sequences={
+                        Array [
+                          Object {
+                            "name": "sequence 1",
+                            "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                          },
+                          Object {
+                            "name": "sequence 2",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 3",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 4",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 5",
+                            "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 6",
+                            "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 7",
+                            "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                          },
+                        ]
+                      }
                       style={
                         Object {
-                          "height": 10,
+                          "paddingTop": 70,
                         }
                       }
-                    />
-                  </div>
+                      tileHeight={20}
+                    >
+                      <withPosition(YBarComponent)
+                        cacheElements={10}
+                        componentCache={[Function]}
+                        height={100}
+                        nrYTiles={6}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        style={
+                          Object {
+                            "paddingTop": 70,
+                          }
+                        }
+                        tileComponent={[Function]}
+                        tileHeight={20}
+                      >
+                        <YBarComponent
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          height={100}
+                          nrYTiles={6}
+                          position={
+                            Object {
+                              "currentViewSequence": 0,
+                              "currentViewSequencePosition": 0,
+                              "lastCurrentViewSequence": 0,
+                              "lastStartYTile": 0,
+                              "xPos": 0,
+                              "xPosOffset": -0,
+                              "yPos": 0,
+                              "yPosOffset": -0,
+                            }
+                          }
+                          positionDispatch={[Function]}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          style={
+                            Object {
+                              "paddingTop": 70,
+                            }
+                          }
+                          tileComponent={[Function]}
+                          tileHeight={20}
+                        >
+                          <div
+                            style={
+                              Object {
+                                "paddingTop": 70,
+                              }
+                            }
+                          >
+                            <div
+                              style={
+                                Object {
+                                  "height": 100,
+                                  "overflow": "hidden",
+                                  "position": "relative",
+                                  "whiteSpace": "nowrap",
+                                }
+                              }
+                            >
+                              <ListComponent
+                                componentCache={[Function]}
+                                endTile={7}
+                                startTile={0}
+                                tileComponent={[Function]}
+                              >
+                                <div>
+                                  <Label
+                                    index={0}
+                                    key="0"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 1
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={1}
+                                    key="1"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 2
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={2}
+                                    key="2"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 3
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={3}
+                                    key="3"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 4
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={4}
+                                    key="4"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 5
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={5}
+                                    key="5"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 6
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={6}
+                                    key="6"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 7
+                                    </div>
+                                  </Label>
+                                </div>
+                              </ListComponent>
+                            </div>
+                          </div>
+                        </YBarComponent>
+                      </withPosition(YBarComponent)>
+                    </HTMLLabelsComponent>
+                  </Connect(HTMLLabelsComponent)>
                 </div>
-              </MSABasicLayout>
-            </Connect(MSABasicLayout)>
+              </MSAInverseLayout>
+            </Connect(MSAInverseLayout)>
           </div>
         </MSALayouter>
       </div>

--- a/src/components/layouts/__snapshots__/full.test.js.snap
+++ b/src/components/layouts/__snapshots__/full.test.js.snap
@@ -2,9 +2,7 @@
 
 exports[`renders without crashing 1`] = `
 <PropsToReduxComponent
-  backgroundColor="red"
   colorScheme="clustal"
-  engine="canvas"
   height={100}
   layout="full"
   sequences={
@@ -44,6 +42,7 @@ exports[`renders without crashing 1`] = `
   width={500}
 >
   <MSAViewerComponent
+    layout="full"
     msaStore={
       Object {
         "dispatch": [Function],
@@ -67,10 +66,11 @@ exports[`renders without crashing 1`] = `
     >
       <div>
         <MSALayouter
-          layout="default"
+          layout="full"
+          onResidueClick={[Function]}
         >
           <div>
-            <Connect(MSABasicLayout)
+            <Connect(MSAInverseLayout)
               forwardedPropsKeys={
                 Array [
                   "sequenceViewerProps",
@@ -80,7 +80,7 @@ exports[`renders without crashing 1`] = `
                 ]
               }
             >
-              <MSABasicLayout
+              <MSAInverseLayout
                 dispatch={[Function]}
                 forwardedPropsKeys={
                   Array [
@@ -99,291 +99,6 @@ exports[`renders without crashing 1`] = `
                     }
                   }
                 >
-                  <Connect(HTMLLabelsComponent)
-                    style={
-                      Object {
-                        "paddingTop": 70,
-                      }
-                    }
-                  >
-                    <HTMLLabelsComponent
-                      cacheElements={10}
-                      dispatch={[Function]}
-                      height={100}
-                      labelStyle={Object {}}
-                      nrYTiles={6}
-                      sequences={
-                        Array [
-                          Object {
-                            "name": "sequence 1",
-                            "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                          },
-                          Object {
-                            "name": "sequence 2",
-                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                          },
-                          Object {
-                            "name": "sequence 3",
-                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                          },
-                          Object {
-                            "name": "sequence 4",
-                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                          },
-                          Object {
-                            "name": "sequence 5",
-                            "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                          },
-                          Object {
-                            "name": "sequence 6",
-                            "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                          },
-                          Object {
-                            "name": "sequence 7",
-                            "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                          },
-                        ]
-                      }
-                      style={
-                        Object {
-                          "paddingTop": 70,
-                        }
-                      }
-                      tileHeight={20}
-                    >
-                      <withPosition(YBarComponent)
-                        cacheElements={10}
-                        componentCache={[Function]}
-                        height={100}
-                        nrYTiles={6}
-                        sequences={
-                          Array [
-                            Object {
-                              "name": "sequence 1",
-                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                            },
-                            Object {
-                              "name": "sequence 2",
-                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 3",
-                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 4",
-                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 5",
-                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 6",
-                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 7",
-                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                            },
-                          ]
-                        }
-                        style={
-                          Object {
-                            "paddingTop": 70,
-                          }
-                        }
-                        tileComponent={[Function]}
-                        tileHeight={20}
-                      >
-                        <YBarComponent
-                          cacheElements={10}
-                          componentCache={[Function]}
-                          height={100}
-                          nrYTiles={6}
-                          position={
-                            Object {
-                              "currentViewSequence": 0,
-                              "currentViewSequencePosition": 0,
-                              "lastCurrentViewSequence": 0,
-                              "lastStartYTile": 0,
-                              "xPos": 0,
-                              "xPosOffset": -0,
-                              "yPos": 0,
-                              "yPosOffset": -0,
-                            }
-                          }
-                          positionDispatch={[Function]}
-                          sequences={
-                            Array [
-                              Object {
-                                "name": "sequence 1",
-                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                              },
-                              Object {
-                                "name": "sequence 2",
-                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                              },
-                              Object {
-                                "name": "sequence 3",
-                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                              },
-                              Object {
-                                "name": "sequence 4",
-                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                              },
-                              Object {
-                                "name": "sequence 5",
-                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                              },
-                              Object {
-                                "name": "sequence 6",
-                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                              },
-                              Object {
-                                "name": "sequence 7",
-                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                              },
-                            ]
-                          }
-                          style={
-                            Object {
-                              "paddingTop": 70,
-                            }
-                          }
-                          tileComponent={[Function]}
-                          tileHeight={20}
-                        >
-                          <div
-                            style={
-                              Object {
-                                "paddingTop": 70,
-                              }
-                            }
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "height": 100,
-                                  "overflow": "hidden",
-                                  "position": "relative",
-                                  "whiteSpace": "nowrap",
-                                }
-                              }
-                            >
-                              <ListComponent
-                                componentCache={[Function]}
-                                endTile={7}
-                                startTile={0}
-                                tileComponent={[Function]}
-                              >
-                                <div>
-                                  <Label
-                                    index={0}
-                                    key="0"
-                                  >
-                                    <div
-                                      style={
-                                        Object {
-                                          "height": 20,
-                                        }
-                                      }
-                                    >
-                                      sequence 1
-                                    </div>
-                                  </Label>
-                                  <Label
-                                    index={1}
-                                    key="1"
-                                  >
-                                    <div
-                                      style={
-                                        Object {
-                                          "height": 20,
-                                        }
-                                      }
-                                    >
-                                      sequence 2
-                                    </div>
-                                  </Label>
-                                  <Label
-                                    index={2}
-                                    key="2"
-                                  >
-                                    <div
-                                      style={
-                                        Object {
-                                          "height": 20,
-                                        }
-                                      }
-                                    >
-                                      sequence 3
-                                    </div>
-                                  </Label>
-                                  <Label
-                                    index={3}
-                                    key="3"
-                                  >
-                                    <div
-                                      style={
-                                        Object {
-                                          "height": 20,
-                                        }
-                                      }
-                                    >
-                                      sequence 4
-                                    </div>
-                                  </Label>
-                                  <Label
-                                    index={4}
-                                    key="4"
-                                  >
-                                    <div
-                                      style={
-                                        Object {
-                                          "height": 20,
-                                        }
-                                      }
-                                    >
-                                      sequence 5
-                                    </div>
-                                  </Label>
-                                  <Label
-                                    index={5}
-                                    key="5"
-                                  >
-                                    <div
-                                      style={
-                                        Object {
-                                          "height": 20,
-                                        }
-                                      }
-                                    >
-                                      sequence 6
-                                    </div>
-                                  </Label>
-                                  <Label
-                                    index={6}
-                                    key="6"
-                                  >
-                                    <div
-                                      style={
-                                        Object {
-                                          "height": 20,
-                                        }
-                                      }
-                                    >
-                                      sequence 7
-                                    </div>
-                                  </Label>
-                                </div>
-                              </ListComponent>
-                            </div>
-                          </div>
-                        </YBarComponent>
-                      </withPosition(YBarComponent)>
-                    </HTMLLabelsComponent>
-                  </Connect(HTMLLabelsComponent)>
                   <div>
                     <Connect(HTMLOverviewBarComponent)
                       height={50}
@@ -2563,17 +2278,295 @@ exports[`renders without crashing 1`] = `
                         </SequenceViewerComponent>
                       </withPosition(SequenceViewerComponent)>
                     </Connect(withPosition(SequenceViewerComponent))>
-                    <div
+                  </div>
+                  <Connect(HTMLLabelsComponent)
+                    style={
+                      Object {
+                        "paddingTop": 70,
+                      }
+                    }
+                  >
+                    <HTMLLabelsComponent
+                      cacheElements={10}
+                      dispatch={[Function]}
+                      height={100}
+                      labelStyle={Object {}}
+                      nrYTiles={6}
+                      sequences={
+                        Array [
+                          Object {
+                            "name": "sequence 1",
+                            "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                          },
+                          Object {
+                            "name": "sequence 2",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 3",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 4",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 5",
+                            "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 6",
+                            "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 7",
+                            "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                          },
+                        ]
+                      }
                       style={
                         Object {
-                          "height": 10,
+                          "paddingTop": 70,
                         }
                       }
-                    />
-                  </div>
+                      tileHeight={20}
+                    >
+                      <withPosition(YBarComponent)
+                        cacheElements={10}
+                        componentCache={[Function]}
+                        height={100}
+                        nrYTiles={6}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        style={
+                          Object {
+                            "paddingTop": 70,
+                          }
+                        }
+                        tileComponent={[Function]}
+                        tileHeight={20}
+                      >
+                        <YBarComponent
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          height={100}
+                          nrYTiles={6}
+                          position={
+                            Object {
+                              "currentViewSequence": 0,
+                              "currentViewSequencePosition": 0,
+                              "lastCurrentViewSequence": 0,
+                              "lastStartYTile": 0,
+                              "xPos": 0,
+                              "xPosOffset": -0,
+                              "yPos": 0,
+                              "yPosOffset": -0,
+                            }
+                          }
+                          positionDispatch={[Function]}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          style={
+                            Object {
+                              "paddingTop": 70,
+                            }
+                          }
+                          tileComponent={[Function]}
+                          tileHeight={20}
+                        >
+                          <div
+                            style={
+                              Object {
+                                "paddingTop": 70,
+                              }
+                            }
+                          >
+                            <div
+                              style={
+                                Object {
+                                  "height": 100,
+                                  "overflow": "hidden",
+                                  "position": "relative",
+                                  "whiteSpace": "nowrap",
+                                }
+                              }
+                            >
+                              <ListComponent
+                                componentCache={[Function]}
+                                endTile={7}
+                                startTile={0}
+                                tileComponent={[Function]}
+                              >
+                                <div>
+                                  <Label
+                                    index={0}
+                                    key="0"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 1
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={1}
+                                    key="1"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 2
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={2}
+                                    key="2"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 3
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={3}
+                                    key="3"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 4
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={4}
+                                    key="4"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 5
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={5}
+                                    key="5"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 6
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={6}
+                                    key="6"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 7
+                                    </div>
+                                  </Label>
+                                </div>
+                              </ListComponent>
+                            </div>
+                          </div>
+                        </YBarComponent>
+                      </withPosition(YBarComponent)>
+                    </HTMLLabelsComponent>
+                  </Connect(HTMLLabelsComponent)>
                 </div>
-              </MSABasicLayout>
-            </Connect(MSABasicLayout)>
+              </MSAInverseLayout>
+            </Connect(MSAInverseLayout)>
           </div>
         </MSALayouter>
       </div>

--- a/src/components/layouts/__snapshots__/full.test.js.snap
+++ b/src/components/layouts/__snapshots__/full.test.js.snap
@@ -1,0 +1,2583 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders without crashing 1`] = `
+<PropsToReduxComponent
+  backgroundColor="red"
+  colorScheme="clustal"
+  engine="canvas"
+  height={100}
+  layout="full"
+  sequences={
+    Array [
+      Object {
+        "name": "sequence 1",
+        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+      },
+      Object {
+        "name": "sequence 2",
+        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+      },
+      Object {
+        "name": "sequence 3",
+        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+      },
+      Object {
+        "name": "sequence 4",
+        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+      },
+      Object {
+        "name": "sequence 5",
+        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+      },
+      Object {
+        "name": "sequence 6",
+        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+      },
+      Object {
+        "name": "sequence 7",
+        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+      },
+    ]
+  }
+  tileHeight={20}
+  tileWidth={20}
+  width={500}
+>
+  <MSAViewerComponent
+    msaStore={
+      Object {
+        "dispatch": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+        Symbol(observable): [Function],
+      }
+    }
+  >
+    <Provider
+      store={
+        Object {
+          "dispatch": [Function],
+          "getState": [Function],
+          "replaceReducer": [Function],
+          "subscribe": [Function],
+          Symbol(observable): [Function],
+        }
+      }
+    >
+      <div>
+        <MSALayouter
+          layout="default"
+        >
+          <div>
+            <Connect(MSABasicLayout)
+              forwardedPropsKeys={
+                Array [
+                  "sequenceViewerProps",
+                  "labelsProps",
+                  "positionBarProps",
+                  "overviewBarProps",
+                ]
+              }
+            >
+              <MSABasicLayout
+                dispatch={[Function]}
+                forwardedPropsKeys={
+                  Array [
+                    "sequenceViewerProps",
+                    "labelsProps",
+                    "positionBarProps",
+                    "overviewBarProps",
+                  ]
+                }
+                tileHeight={20}
+              >
+                <div
+                  style={
+                    Object {
+                      "display": "flex",
+                    }
+                  }
+                >
+                  <Connect(HTMLLabelsComponent)
+                    style={
+                      Object {
+                        "paddingTop": 70,
+                      }
+                    }
+                  >
+                    <HTMLLabelsComponent
+                      cacheElements={10}
+                      dispatch={[Function]}
+                      height={100}
+                      labelStyle={Object {}}
+                      nrYTiles={6}
+                      sequences={
+                        Array [
+                          Object {
+                            "name": "sequence 1",
+                            "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                          },
+                          Object {
+                            "name": "sequence 2",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 3",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 4",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 5",
+                            "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 6",
+                            "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 7",
+                            "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                          },
+                        ]
+                      }
+                      style={
+                        Object {
+                          "paddingTop": 70,
+                        }
+                      }
+                      tileHeight={20}
+                    >
+                      <withPosition(YBarComponent)
+                        cacheElements={10}
+                        componentCache={[Function]}
+                        height={100}
+                        nrYTiles={6}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        style={
+                          Object {
+                            "paddingTop": 70,
+                          }
+                        }
+                        tileComponent={[Function]}
+                        tileHeight={20}
+                      >
+                        <YBarComponent
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          height={100}
+                          nrYTiles={6}
+                          position={
+                            Object {
+                              "currentViewSequence": 0,
+                              "currentViewSequencePosition": 0,
+                              "lastCurrentViewSequence": 0,
+                              "lastStartYTile": 0,
+                              "xPos": 0,
+                              "xPosOffset": -0,
+                              "yPos": 0,
+                              "yPosOffset": -0,
+                            }
+                          }
+                          positionDispatch={[Function]}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          style={
+                            Object {
+                              "paddingTop": 70,
+                            }
+                          }
+                          tileComponent={[Function]}
+                          tileHeight={20}
+                        >
+                          <div
+                            style={
+                              Object {
+                                "paddingTop": 70,
+                              }
+                            }
+                          >
+                            <div
+                              style={
+                                Object {
+                                  "height": 100,
+                                  "overflow": "hidden",
+                                  "position": "relative",
+                                  "whiteSpace": "nowrap",
+                                }
+                              }
+                            >
+                              <ListComponent
+                                componentCache={[Function]}
+                                endTile={7}
+                                startTile={0}
+                                tileComponent={[Function]}
+                              >
+                                <div>
+                                  <Label
+                                    index={0}
+                                    key="0"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 1
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={1}
+                                    key="1"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 2
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={2}
+                                    key="2"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 3
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={3}
+                                    key="3"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 4
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={4}
+                                    key="4"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 5
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={5}
+                                    key="5"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 6
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={6}
+                                    key="6"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 7
+                                    </div>
+                                  </Label>
+                                </div>
+                              </ListComponent>
+                            </div>
+                          </div>
+                        </YBarComponent>
+                      </withPosition(YBarComponent)>
+                    </HTMLLabelsComponent>
+                  </Connect(HTMLLabelsComponent)>
+                  <div>
+                    <Connect(HTMLOverviewBarComponent)
+                      height={50}
+                    >
+                      <HTMLOverviewBarComponent
+                        cacheElements={10}
+                        dispatch={[Function]}
+                        fillColor="#999999"
+                        height={50}
+                        maxLength={60}
+                        method="conservation"
+                        nrXTiles={26}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        tileWidth={20}
+                        width={500}
+                      >
+                        <withPosition(XBarComponent)
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          maxLength={60}
+                          nrXTiles={26}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          tileComponent={[Function]}
+                          tileWidth={20}
+                          width={500}
+                        >
+                          <XBarComponent
+                            cacheElements={10}
+                            componentCache={[Function]}
+                            maxLength={60}
+                            nrXTiles={26}
+                            position={
+                              Object {
+                                "currentViewSequence": 0,
+                                "currentViewSequencePosition": 0,
+                                "lastCurrentViewSequencePosition": 0,
+                                "lastStartXTile": 0,
+                                "xPos": 0,
+                                "xPosOffset": -0,
+                                "yPos": 0,
+                                "yPosOffset": -0,
+                              }
+                            }
+                            positionDispatch={[Function]}
+                            sequences={
+                              Array [
+                                Object {
+                                  "name": "sequence 1",
+                                  "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                },
+                                Object {
+                                  "name": "sequence 2",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 3",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 4",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 5",
+                                  "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 6",
+                                  "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 7",
+                                  "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                },
+                              ]
+                            }
+                            tileComponent={[Function]}
+                            tileWidth={20}
+                            width={500}
+                          >
+                            <div
+                              style={
+                                Object {
+                                  "height": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                style={
+                                  Object {
+                                    "overflow": "hidden",
+                                    "position": "relative",
+                                    "whiteSpace": "nowrap",
+                                    "width": 500,
+                                  }
+                                }
+                              >
+                                <ListComponent
+                                  componentCache={[Function]}
+                                  endTile={46}
+                                  maxWidth={900}
+                                  sequences={
+                                    Array [
+                                      Object {
+                                        "name": "sequence 1",
+                                        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                      },
+                                      Object {
+                                        "name": "sequence 2",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 3",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 4",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 5",
+                                        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 6",
+                                        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 7",
+                                        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                      },
+                                    ]
+                                  }
+                                  startTile={0}
+                                  tileComponent={[Function]}
+                                  tileWidth={20}
+                                >
+                                  <div>
+                                    <Bar
+                                      index={0}
+                                      key="0"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={1}
+                                      key="1"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={2}
+                                      key="2"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={3}
+                                      key="3"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={4}
+                                      key="4"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={5}
+                                      key="5"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 34,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={6}
+                                      key="6"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={7}
+                                      key="7"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 32,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={8}
+                                      key="8"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={9}
+                                      key="9"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={10}
+                                      key="10"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 28,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={11}
+                                      key="11"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 21,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={12}
+                                      key="12"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={13}
+                                      key="13"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={14}
+                                      key="14"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={15}
+                                      key="15"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={16}
+                                      key="16"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={17}
+                                      key="17"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={18}
+                                      key="18"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={19}
+                                      key="19"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={20}
+                                      key="20"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={21}
+                                      key="21"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={22}
+                                      key="22"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={23}
+                                      key="23"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={24}
+                                      key="24"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={25}
+                                      key="25"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={26}
+                                      key="26"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={27}
+                                      key="27"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={28}
+                                      key="28"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={29}
+                                      key="29"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={30}
+                                      key="30"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={31}
+                                      key="31"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={32}
+                                      key="32"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={33}
+                                      key="33"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={34}
+                                      key="34"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={35}
+                                      key="35"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={36}
+                                      key="36"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={37}
+                                      key="37"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={38}
+                                      key="38"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={39}
+                                      key="39"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={40}
+                                      key="40"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={41}
+                                      key="41"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={42}
+                                      key="42"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={43}
+                                      key="43"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={44}
+                                      key="44"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={45}
+                                      key="45"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                  </div>
+                                </ListComponent>
+                              </div>
+                            </div>
+                          </XBarComponent>
+                        </withPosition(XBarComponent)>
+                      </HTMLOverviewBarComponent>
+                    </Connect(HTMLOverviewBarComponent)>
+                    <Connect(HTMLPositionBarComponent)>
+                      <HTMLPositionBarComponent
+                        cacheElements={10}
+                        dispatch={[Function]}
+                        height={15}
+                        markerSteps={2}
+                        markerStyle={Object {}}
+                        maxLength={60}
+                        nrXTiles={26}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        startIndex={1}
+                        style={
+                          Object {
+                            "font": "12px Arial",
+                          }
+                        }
+                        tileWidth={20}
+                        width={500}
+                      >
+                        <withPosition(XBarComponent)
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          height={15}
+                          maxLength={60}
+                          nrXTiles={26}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          style={
+                            Object {
+                              "font": "12px Arial",
+                            }
+                          }
+                          tileComponent={[Function]}
+                          tileWidth={20}
+                          width={500}
+                        >
+                          <XBarComponent
+                            cacheElements={10}
+                            componentCache={[Function]}
+                            height={15}
+                            maxLength={60}
+                            nrXTiles={26}
+                            position={
+                              Object {
+                                "currentViewSequence": 0,
+                                "currentViewSequencePosition": 0,
+                                "lastCurrentViewSequencePosition": 0,
+                                "lastStartXTile": 0,
+                                "xPos": 0,
+                                "xPosOffset": -0,
+                                "yPos": 0,
+                                "yPosOffset": -0,
+                              }
+                            }
+                            positionDispatch={[Function]}
+                            sequences={
+                              Array [
+                                Object {
+                                  "name": "sequence 1",
+                                  "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                },
+                                Object {
+                                  "name": "sequence 2",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 3",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 4",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 5",
+                                  "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 6",
+                                  "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 7",
+                                  "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                },
+                              ]
+                            }
+                            style={
+                              Object {
+                                "font": "12px Arial",
+                              }
+                            }
+                            tileComponent={[Function]}
+                            tileWidth={20}
+                            width={500}
+                          >
+                            <div
+                              height={15}
+                              style={
+                                Object {
+                                  "font": "12px Arial",
+                                }
+                              }
+                            >
+                              <div
+                                style={
+                                  Object {
+                                    "overflow": "hidden",
+                                    "position": "relative",
+                                    "whiteSpace": "nowrap",
+                                    "width": 500,
+                                  }
+                                }
+                              >
+                                <ListComponent
+                                  componentCache={[Function]}
+                                  endTile={46}
+                                  maxWidth={900}
+                                  sequences={
+                                    Array [
+                                      Object {
+                                        "name": "sequence 1",
+                                        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                      },
+                                      Object {
+                                        "name": "sequence 2",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 3",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 4",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 5",
+                                        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 6",
+                                        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 7",
+                                        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                      },
+                                    ]
+                                  }
+                                  startTile={0}
+                                  tileComponent={[Function]}
+                                  tileWidth={20}
+                                >
+                                  <div>
+                                    <Marker
+                                      index={0}
+                                      key="0"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        1
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={1}
+                                      key="1"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={2}
+                                      key="2"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        3
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={3}
+                                      key="3"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={4}
+                                      key="4"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        5
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={5}
+                                      key="5"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={6}
+                                      key="6"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        7
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={7}
+                                      key="7"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={8}
+                                      key="8"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        9
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={9}
+                                      key="9"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={10}
+                                      key="10"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        11
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={11}
+                                      key="11"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={12}
+                                      key="12"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        13
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={13}
+                                      key="13"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={14}
+                                      key="14"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        15
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={15}
+                                      key="15"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={16}
+                                      key="16"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        17
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={17}
+                                      key="17"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={18}
+                                      key="18"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        19
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={19}
+                                      key="19"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={20}
+                                      key="20"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        21
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={21}
+                                      key="21"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={22}
+                                      key="22"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        23
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={23}
+                                      key="23"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={24}
+                                      key="24"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        25
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={25}
+                                      key="25"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={26}
+                                      key="26"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        27
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={27}
+                                      key="27"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={28}
+                                      key="28"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        29
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={29}
+                                      key="29"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={30}
+                                      key="30"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        31
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={31}
+                                      key="31"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={32}
+                                      key="32"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        33
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={33}
+                                      key="33"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={34}
+                                      key="34"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        35
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={35}
+                                      key="35"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={36}
+                                      key="36"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        37
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={37}
+                                      key="37"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={38}
+                                      key="38"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        39
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={39}
+                                      key="39"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={40}
+                                      key="40"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        41
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={41}
+                                      key="41"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={42}
+                                      key="42"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        43
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={43}
+                                      key="43"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={44}
+                                      key="44"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        45
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={45}
+                                      key="45"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                  </div>
+                                </ListComponent>
+                              </div>
+                            </div>
+                          </XBarComponent>
+                        </withPosition(XBarComponent)>
+                      </HTMLPositionBarComponent>
+                    </Connect(HTMLPositionBarComponent)>
+                    <Connect(withPosition(SequenceViewerComponent))>
+                      <withPosition(SequenceViewerComponent)
+                        colorScheme={
+                          ColorScheme {
+                            "scheme": StaticSchemeClass {
+                              "defaultColor": "#ffffff",
+                              "getColor": [Function],
+                              "map": Object {
+                                "A": "orange",
+                                "B": "#fff",
+                                "C": "green",
+                                "D": "red",
+                                "E": "red",
+                                "F": "blue",
+                                "G": "orange",
+                                "Gap": "#fff",
+                                "H": "red",
+                                "I": "green",
+                                "J": "#fff",
+                                "K": "red",
+                                "L": "green",
+                                "M": "green",
+                                "N": "#fff",
+                                "O": "#fff",
+                                "P": "orange",
+                                "Q": "#fff",
+                                "R": "red",
+                                "S": "orange",
+                                "T": "orange",
+                                "U": "#fff",
+                                "V": "green",
+                                "W": "blue",
+                                "X": "#fff",
+                                "Y": "blue",
+                                "Z": "#fff",
+                              },
+                              "type": "static",
+                            },
+                          }
+                        }
+                        dispatch={[Function]}
+                        fullHeight={140}
+                        fullWidth={1200}
+                        height={100}
+                        nrXTiles={26}
+                        nrYTiles={6}
+                        sequences={
+                          Object {
+                            "length": 7,
+                            "maxLength": 60,
+                            "raw": Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ],
+                          }
+                        }
+                        tileHeight={20}
+                        tileWidth={20}
+                        width={500}
+                      >
+                        <SequenceViewerComponent
+                          border={false}
+                          borderColor="black"
+                          borderWidth={1}
+                          cacheElements={20}
+                          colorScheme={
+                            ColorScheme {
+                              "scheme": StaticSchemeClass {
+                                "defaultColor": "#ffffff",
+                                "getColor": [Function],
+                                "map": Object {
+                                  "A": "orange",
+                                  "B": "#fff",
+                                  "C": "green",
+                                  "D": "red",
+                                  "E": "red",
+                                  "F": "blue",
+                                  "G": "orange",
+                                  "Gap": "#fff",
+                                  "H": "red",
+                                  "I": "green",
+                                  "J": "#fff",
+                                  "K": "red",
+                                  "L": "green",
+                                  "M": "green",
+                                  "N": "#fff",
+                                  "O": "#fff",
+                                  "P": "orange",
+                                  "Q": "#fff",
+                                  "R": "red",
+                                  "S": "orange",
+                                  "T": "orange",
+                                  "U": "#fff",
+                                  "V": "green",
+                                  "W": "blue",
+                                  "X": "#fff",
+                                  "Y": "blue",
+                                  "Z": "#fff",
+                                },
+                                "type": "static",
+                              },
+                            }
+                          }
+                          dispatch={[Function]}
+                          fullHeight={140}
+                          fullWidth={1200}
+                          height={100}
+                          nrXTiles={26}
+                          nrYTiles={6}
+                          overflow="hidden"
+                          overflowX="auto"
+                          overflowY="auto"
+                          position={
+                            Object {
+                              "currentViewSequence": 0,
+                              "currentViewSequencePosition": 0,
+                              "xPos": 0,
+                              "xPosOffset": -0,
+                              "yPos": 0,
+                              "yPosOffset": -0,
+                            }
+                          }
+                          positionDispatch={[Function]}
+                          scrollBarPositionX="bottom"
+                          scrollBarPositionY="right"
+                          sequences={
+                            Object {
+                              "length": 7,
+                              "maxLength": 60,
+                              "raw": Array [
+                                Object {
+                                  "name": "sequence 1",
+                                  "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                },
+                                Object {
+                                  "name": "sequence 2",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 3",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 4",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 5",
+                                  "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 6",
+                                  "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 7",
+                                  "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                },
+                              ],
+                            }
+                          }
+                          showModBar={false}
+                          textColor="black"
+                          textFont="18px Arial"
+                          tileHeight={20}
+                          tileWidth={20}
+                          width={500}
+                          xGridSize={10}
+                          yGridSize={10}
+                        >
+                          <div
+                            height={100}
+                            style={
+                              Object {
+                                "cursor": "grab",
+                                "height": 100,
+                                "position": "relative",
+                                "width": 500,
+                              }
+                            }
+                            width={500}
+                          >
+                            <canvas
+                              height={100}
+                              style={
+                                Object {
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "top": 0,
+                                }
+                              }
+                              width={500}
+                            >
+                              Your browser does not seem to support HTML5 canvas.
+                            </canvas>
+                            <canvas
+                              height={100}
+                              style={
+                                Object {
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "top": 0,
+                                }
+                              }
+                              width={500}
+                            >
+                              Your browser does not seem to support HTML5 canvas.
+                            </canvas>
+                            <withPosition(FakeScroll)
+                              fullHeight={140}
+                              fullWidth={1200}
+                              height={100}
+                              overflow="hidden"
+                              overflowX="auto"
+                              overflowY="auto"
+                              positionX="bottom"
+                              positionY="right"
+                              width={500}
+                            >
+                              <FakeScroll
+                                fullHeight={140}
+                                fullWidth={1200}
+                                height={100}
+                                overflow="hidden"
+                                overflowX="auto"
+                                overflowY="auto"
+                                position={
+                                  Object {
+                                    "currentViewSequence": 0,
+                                    "currentViewSequencePosition": 0,
+                                    "xPos": 0,
+                                    "xPosOffset": -0,
+                                    "yPos": 0,
+                                    "yPosOffset": -0,
+                                  }
+                                }
+                                positionDispatch={[Function]}
+                                positionX="bottom"
+                                positionY="right"
+                                scrollBarWidth={5}
+                                width={500}
+                              >
+                                <div />
+                              </FakeScroll>
+                            </withPosition(FakeScroll)>
+                          </div>
+                        </SequenceViewerComponent>
+                      </withPosition(SequenceViewerComponent)>
+                    </Connect(withPosition(SequenceViewerComponent))>
+                    <div
+                      style={
+                        Object {
+                          "height": 10,
+                        }
+                      }
+                    />
+                  </div>
+                </div>
+              </MSABasicLayout>
+            </Connect(MSABasicLayout)>
+          </div>
+        </MSALayouter>
+      </div>
+    </Provider>
+  </MSAViewerComponent>
+</PropsToReduxComponent>
+`;

--- a/src/components/layouts/__snapshots__/funky.test.js.snap
+++ b/src/components/layouts/__snapshots__/funky.test.js.snap
@@ -2,9 +2,7 @@
 
 exports[`renders without crashing 1`] = `
 <PropsToReduxComponent
-  backgroundColor="red"
   colorScheme="clustal"
-  engine="canvas"
   height={100}
   layout="funky"
   sequences={
@@ -44,6 +42,7 @@ exports[`renders without crashing 1`] = `
   width={500}
 >
   <MSAViewerComponent
+    layout="funky"
     msaStore={
       Object {
         "dispatch": [Function],
@@ -67,10 +66,11 @@ exports[`renders without crashing 1`] = `
     >
       <div>
         <MSALayouter
-          layout="default"
+          layout="funky"
+          onResidueClick={[Function]}
         >
           <div>
-            <Connect(MSABasicLayout)
+            <Connect(MSAFunkyLayout)
               forwardedPropsKeys={
                 Array [
                   "sequenceViewerProps",
@@ -80,7 +80,7 @@ exports[`renders without crashing 1`] = `
                 ]
               }
             >
-              <MSABasicLayout
+              <MSAFunkyLayout
                 dispatch={[Function]}
                 forwardedPropsKeys={
                   Array [
@@ -102,7 +102,7 @@ exports[`renders without crashing 1`] = `
                   <Connect(HTMLLabelsComponent)
                     style={
                       Object {
-                        "paddingTop": 70,
+                        "paddingTop": 20,
                       }
                     }
                   >
@@ -146,7 +146,7 @@ exports[`renders without crashing 1`] = `
                       }
                       style={
                         Object {
-                          "paddingTop": 70,
+                          "paddingTop": 20,
                         }
                       }
                       tileHeight={20}
@@ -190,7 +190,7 @@ exports[`renders without crashing 1`] = `
                         }
                         style={
                           Object {
-                            "paddingTop": 70,
+                            "paddingTop": 20,
                           }
                         }
                         tileComponent={[Function]}
@@ -248,7 +248,7 @@ exports[`renders without crashing 1`] = `
                           }
                           style={
                             Object {
-                              "paddingTop": 70,
+                              "paddingTop": 20,
                             }
                           }
                           tileComponent={[Function]}
@@ -257,7 +257,7 @@ exports[`renders without crashing 1`] = `
                           <div
                             style={
                               Object {
-                                "paddingTop": 70,
+                                "paddingTop": 20,
                               }
                             }
                           >
@@ -385,949 +385,6 @@ exports[`renders without crashing 1`] = `
                     </HTMLLabelsComponent>
                   </Connect(HTMLLabelsComponent)>
                   <div>
-                    <Connect(HTMLOverviewBarComponent)
-                      height={50}
-                    >
-                      <HTMLOverviewBarComponent
-                        cacheElements={10}
-                        dispatch={[Function]}
-                        fillColor="#999999"
-                        height={50}
-                        maxLength={60}
-                        method="conservation"
-                        nrXTiles={26}
-                        sequences={
-                          Array [
-                            Object {
-                              "name": "sequence 1",
-                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                            },
-                            Object {
-                              "name": "sequence 2",
-                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 3",
-                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 4",
-                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 5",
-                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 6",
-                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 7",
-                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                            },
-                          ]
-                        }
-                        tileWidth={20}
-                        width={500}
-                      >
-                        <withPosition(XBarComponent)
-                          cacheElements={10}
-                          componentCache={[Function]}
-                          maxLength={60}
-                          nrXTiles={26}
-                          sequences={
-                            Array [
-                              Object {
-                                "name": "sequence 1",
-                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                              },
-                              Object {
-                                "name": "sequence 2",
-                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                              },
-                              Object {
-                                "name": "sequence 3",
-                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                              },
-                              Object {
-                                "name": "sequence 4",
-                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                              },
-                              Object {
-                                "name": "sequence 5",
-                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                              },
-                              Object {
-                                "name": "sequence 6",
-                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                              },
-                              Object {
-                                "name": "sequence 7",
-                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                              },
-                            ]
-                          }
-                          tileComponent={[Function]}
-                          tileWidth={20}
-                          width={500}
-                        >
-                          <XBarComponent
-                            cacheElements={10}
-                            componentCache={[Function]}
-                            maxLength={60}
-                            nrXTiles={26}
-                            position={
-                              Object {
-                                "currentViewSequence": 0,
-                                "currentViewSequencePosition": 0,
-                                "lastCurrentViewSequencePosition": 0,
-                                "lastStartXTile": 0,
-                                "xPos": 0,
-                                "xPosOffset": -0,
-                                "yPos": 0,
-                                "yPosOffset": -0,
-                              }
-                            }
-                            positionDispatch={[Function]}
-                            sequences={
-                              Array [
-                                Object {
-                                  "name": "sequence 1",
-                                  "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                                },
-                                Object {
-                                  "name": "sequence 2",
-                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                                },
-                                Object {
-                                  "name": "sequence 3",
-                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                                },
-                                Object {
-                                  "name": "sequence 4",
-                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                                },
-                                Object {
-                                  "name": "sequence 5",
-                                  "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                                },
-                                Object {
-                                  "name": "sequence 6",
-                                  "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                                },
-                                Object {
-                                  "name": "sequence 7",
-                                  "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                                },
-                              ]
-                            }
-                            tileComponent={[Function]}
-                            tileWidth={20}
-                            width={500}
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "height": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                style={
-                                  Object {
-                                    "overflow": "hidden",
-                                    "position": "relative",
-                                    "whiteSpace": "nowrap",
-                                    "width": 500,
-                                  }
-                                }
-                              >
-                                <ListComponent
-                                  componentCache={[Function]}
-                                  endTile={46}
-                                  maxWidth={900}
-                                  sequences={
-                                    Array [
-                                      Object {
-                                        "name": "sequence 1",
-                                        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                                      },
-                                      Object {
-                                        "name": "sequence 2",
-                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                                      },
-                                      Object {
-                                        "name": "sequence 3",
-                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                                      },
-                                      Object {
-                                        "name": "sequence 4",
-                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                                      },
-                                      Object {
-                                        "name": "sequence 5",
-                                        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                                      },
-                                      Object {
-                                        "name": "sequence 6",
-                                        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                                      },
-                                      Object {
-                                        "name": "sequence 7",
-                                        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                                      },
-                                    ]
-                                  }
-                                  startTile={0}
-                                  tileComponent={[Function]}
-                                  tileWidth={20}
-                                >
-                                  <div>
-                                    <Bar
-                                      index={0}
-                                      key="0"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={1}
-                                      key="1"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={2}
-                                      key="2"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={3}
-                                      key="3"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={4}
-                                      key="4"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={5}
-                                      key="5"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 34,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={6}
-                                      key="6"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={7}
-                                      key="7"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 32,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={8}
-                                      key="8"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={9}
-                                      key="9"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 35,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={10}
-                                      key="10"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 28,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={11}
-                                      key="11"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 21,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={12}
-                                      key="12"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={13}
-                                      key="13"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={14}
-                                      key="14"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={15}
-                                      key="15"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={16}
-                                      key="16"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 35,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={17}
-                                      key="17"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={18}
-                                      key="18"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={19}
-                                      key="19"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={20}
-                                      key="20"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={21}
-                                      key="21"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={22}
-                                      key="22"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={23}
-                                      key="23"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={24}
-                                      key="24"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 35,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={25}
-                                      key="25"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 35,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={26}
-                                      key="26"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={27}
-                                      key="27"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={28}
-                                      key="28"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 35,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={29}
-                                      key="29"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={30}
-                                      key="30"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={31}
-                                      key="31"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={32}
-                                      key="32"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={33}
-                                      key="33"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={34}
-                                      key="34"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 35,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={35}
-                                      key="35"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={36}
-                                      key="36"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={37}
-                                      key="37"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={38}
-                                      key="38"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={39}
-                                      key="39"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 35,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={40}
-                                      key="40"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 35,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={41}
-                                      key="41"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={42}
-                                      key="42"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 35,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={43}
-                                      key="43"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 35,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={44}
-                                      key="44"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 35,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                    <Bar
-                                      index={45}
-                                      key="45"
-                                    >
-                                      <div
-                                        style={
-                                          Object {
-                                            "backgroundColor": "#999999",
-                                            "display": "inline-block",
-                                            "height": 50,
-                                            "textAlign": "center",
-                                            "width": 20,
-                                          }
-                                        }
-                                      />
-                                    </Bar>
-                                  </div>
-                                </ListComponent>
-                              </div>
-                            </div>
-                          </XBarComponent>
-                        </withPosition(XBarComponent)>
-                      </HTMLOverviewBarComponent>
-                    </Connect(HTMLOverviewBarComponent)>
                     <Connect(HTMLPositionBarComponent)>
                       <HTMLPositionBarComponent
                         cacheElements={10}
@@ -2563,17 +1620,3157 @@ exports[`renders without crashing 1`] = `
                         </SequenceViewerComponent>
                       </withPosition(SequenceViewerComponent)>
                     </Connect(withPosition(SequenceViewerComponent))>
-                    <div
+                    <Connect(HTMLPositionBarComponent)>
+                      <HTMLPositionBarComponent
+                        cacheElements={10}
+                        dispatch={[Function]}
+                        height={15}
+                        markerSteps={2}
+                        markerStyle={Object {}}
+                        maxLength={60}
+                        nrXTiles={26}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        startIndex={1}
+                        style={
+                          Object {
+                            "font": "12px Arial",
+                          }
+                        }
+                        tileWidth={20}
+                        width={500}
+                      >
+                        <withPosition(XBarComponent)
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          height={15}
+                          maxLength={60}
+                          nrXTiles={26}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          style={
+                            Object {
+                              "font": "12px Arial",
+                            }
+                          }
+                          tileComponent={[Function]}
+                          tileWidth={20}
+                          width={500}
+                        >
+                          <XBarComponent
+                            cacheElements={10}
+                            componentCache={[Function]}
+                            height={15}
+                            maxLength={60}
+                            nrXTiles={26}
+                            position={
+                              Object {
+                                "currentViewSequence": 0,
+                                "currentViewSequencePosition": 0,
+                                "lastCurrentViewSequencePosition": 0,
+                                "lastStartXTile": 0,
+                                "xPos": 0,
+                                "xPosOffset": -0,
+                                "yPos": 0,
+                                "yPosOffset": -0,
+                              }
+                            }
+                            positionDispatch={[Function]}
+                            sequences={
+                              Array [
+                                Object {
+                                  "name": "sequence 1",
+                                  "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                },
+                                Object {
+                                  "name": "sequence 2",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 3",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 4",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 5",
+                                  "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 6",
+                                  "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 7",
+                                  "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                },
+                              ]
+                            }
+                            style={
+                              Object {
+                                "font": "12px Arial",
+                              }
+                            }
+                            tileComponent={[Function]}
+                            tileWidth={20}
+                            width={500}
+                          >
+                            <div
+                              height={15}
+                              style={
+                                Object {
+                                  "font": "12px Arial",
+                                }
+                              }
+                            >
+                              <div
+                                style={
+                                  Object {
+                                    "overflow": "hidden",
+                                    "position": "relative",
+                                    "whiteSpace": "nowrap",
+                                    "width": 500,
+                                  }
+                                }
+                              >
+                                <ListComponent
+                                  componentCache={[Function]}
+                                  endTile={46}
+                                  maxWidth={900}
+                                  sequences={
+                                    Array [
+                                      Object {
+                                        "name": "sequence 1",
+                                        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                      },
+                                      Object {
+                                        "name": "sequence 2",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 3",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 4",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 5",
+                                        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 6",
+                                        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 7",
+                                        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                      },
+                                    ]
+                                  }
+                                  startTile={0}
+                                  tileComponent={[Function]}
+                                  tileWidth={20}
+                                >
+                                  <div>
+                                    <Marker
+                                      index={0}
+                                      key="0"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        1
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={1}
+                                      key="1"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={2}
+                                      key="2"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        3
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={3}
+                                      key="3"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={4}
+                                      key="4"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        5
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={5}
+                                      key="5"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={6}
+                                      key="6"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        7
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={7}
+                                      key="7"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={8}
+                                      key="8"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        9
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={9}
+                                      key="9"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={10}
+                                      key="10"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        11
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={11}
+                                      key="11"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={12}
+                                      key="12"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        13
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={13}
+                                      key="13"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={14}
+                                      key="14"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        15
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={15}
+                                      key="15"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={16}
+                                      key="16"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        17
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={17}
+                                      key="17"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={18}
+                                      key="18"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        19
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={19}
+                                      key="19"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={20}
+                                      key="20"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        21
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={21}
+                                      key="21"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={22}
+                                      key="22"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        23
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={23}
+                                      key="23"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={24}
+                                      key="24"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        25
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={25}
+                                      key="25"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={26}
+                                      key="26"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        27
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={27}
+                                      key="27"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={28}
+                                      key="28"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        29
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={29}
+                                      key="29"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={30}
+                                      key="30"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        31
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={31}
+                                      key="31"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={32}
+                                      key="32"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        33
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={33}
+                                      key="33"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={34}
+                                      key="34"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        35
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={35}
+                                      key="35"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={36}
+                                      key="36"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        37
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={37}
+                                      key="37"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={38}
+                                      key="38"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        39
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={39}
+                                      key="39"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={40}
+                                      key="40"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        41
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={41}
+                                      key="41"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={42}
+                                      key="42"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        43
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={43}
+                                      key="43"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={44}
+                                      key="44"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        45
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={45}
+                                      key="45"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                  </div>
+                                </ListComponent>
+                              </div>
+                            </div>
+                          </XBarComponent>
+                        </withPosition(XBarComponent)>
+                      </HTMLPositionBarComponent>
+                    </Connect(HTMLPositionBarComponent)>
+                    <Connect(HTMLOverviewBarComponent)>
+                      <HTMLOverviewBarComponent
+                        cacheElements={10}
+                        dispatch={[Function]}
+                        fillColor="#999999"
+                        height={50}
+                        maxLength={60}
+                        method="conservation"
+                        nrXTiles={26}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        tileWidth={20}
+                        width={500}
+                      >
+                        <withPosition(XBarComponent)
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          maxLength={60}
+                          nrXTiles={26}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          tileComponent={[Function]}
+                          tileWidth={20}
+                          width={500}
+                        >
+                          <XBarComponent
+                            cacheElements={10}
+                            componentCache={[Function]}
+                            maxLength={60}
+                            nrXTiles={26}
+                            position={
+                              Object {
+                                "currentViewSequence": 0,
+                                "currentViewSequencePosition": 0,
+                                "lastCurrentViewSequencePosition": 0,
+                                "lastStartXTile": 0,
+                                "xPos": 0,
+                                "xPosOffset": -0,
+                                "yPos": 0,
+                                "yPosOffset": -0,
+                              }
+                            }
+                            positionDispatch={[Function]}
+                            sequences={
+                              Array [
+                                Object {
+                                  "name": "sequence 1",
+                                  "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                },
+                                Object {
+                                  "name": "sequence 2",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 3",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 4",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 5",
+                                  "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 6",
+                                  "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 7",
+                                  "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                },
+                              ]
+                            }
+                            tileComponent={[Function]}
+                            tileWidth={20}
+                            width={500}
+                          >
+                            <div
+                              style={
+                                Object {
+                                  "height": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                style={
+                                  Object {
+                                    "overflow": "hidden",
+                                    "position": "relative",
+                                    "whiteSpace": "nowrap",
+                                    "width": 500,
+                                  }
+                                }
+                              >
+                                <ListComponent
+                                  componentCache={[Function]}
+                                  endTile={46}
+                                  maxWidth={900}
+                                  sequences={
+                                    Array [
+                                      Object {
+                                        "name": "sequence 1",
+                                        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                      },
+                                      Object {
+                                        "name": "sequence 2",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 3",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 4",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 5",
+                                        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 6",
+                                        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 7",
+                                        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                      },
+                                    ]
+                                  }
+                                  startTile={0}
+                                  tileComponent={[Function]}
+                                  tileWidth={20}
+                                >
+                                  <div>
+                                    <Bar
+                                      index={0}
+                                      key="0"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={1}
+                                      key="1"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={2}
+                                      key="2"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={3}
+                                      key="3"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={4}
+                                      key="4"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={5}
+                                      key="5"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 34,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={6}
+                                      key="6"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={7}
+                                      key="7"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 32,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={8}
+                                      key="8"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={9}
+                                      key="9"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={10}
+                                      key="10"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 28,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={11}
+                                      key="11"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 21,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={12}
+                                      key="12"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={13}
+                                      key="13"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={14}
+                                      key="14"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={15}
+                                      key="15"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={16}
+                                      key="16"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={17}
+                                      key="17"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={18}
+                                      key="18"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={19}
+                                      key="19"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={20}
+                                      key="20"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={21}
+                                      key="21"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={22}
+                                      key="22"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={23}
+                                      key="23"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={24}
+                                      key="24"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={25}
+                                      key="25"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={26}
+                                      key="26"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={27}
+                                      key="27"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={28}
+                                      key="28"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={29}
+                                      key="29"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={30}
+                                      key="30"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={31}
+                                      key="31"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={32}
+                                      key="32"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={33}
+                                      key="33"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={34}
+                                      key="34"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={35}
+                                      key="35"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={36}
+                                      key="36"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={37}
+                                      key="37"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={38}
+                                      key="38"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={39}
+                                      key="39"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={40}
+                                      key="40"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={41}
+                                      key="41"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={42}
+                                      key="42"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={43}
+                                      key="43"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={44}
+                                      key="44"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={45}
+                                      key="45"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                  </div>
+                                </ListComponent>
+                              </div>
+                            </div>
+                          </XBarComponent>
+                        </withPosition(XBarComponent)>
+                      </HTMLOverviewBarComponent>
+                    </Connect(HTMLOverviewBarComponent)>
+                    <br />
+                    <Connect(HTMLPositionBarComponent)>
+                      <HTMLPositionBarComponent
+                        cacheElements={10}
+                        dispatch={[Function]}
+                        height={15}
+                        markerSteps={2}
+                        markerStyle={Object {}}
+                        maxLength={60}
+                        nrXTiles={26}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        startIndex={1}
+                        style={
+                          Object {
+                            "font": "12px Arial",
+                          }
+                        }
+                        tileWidth={20}
+                        width={500}
+                      >
+                        <withPosition(XBarComponent)
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          height={15}
+                          maxLength={60}
+                          nrXTiles={26}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          style={
+                            Object {
+                              "font": "12px Arial",
+                            }
+                          }
+                          tileComponent={[Function]}
+                          tileWidth={20}
+                          width={500}
+                        >
+                          <XBarComponent
+                            cacheElements={10}
+                            componentCache={[Function]}
+                            height={15}
+                            maxLength={60}
+                            nrXTiles={26}
+                            position={
+                              Object {
+                                "currentViewSequence": 0,
+                                "currentViewSequencePosition": 0,
+                                "lastCurrentViewSequencePosition": 0,
+                                "lastStartXTile": 0,
+                                "xPos": 0,
+                                "xPosOffset": -0,
+                                "yPos": 0,
+                                "yPosOffset": -0,
+                              }
+                            }
+                            positionDispatch={[Function]}
+                            sequences={
+                              Array [
+                                Object {
+                                  "name": "sequence 1",
+                                  "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                },
+                                Object {
+                                  "name": "sequence 2",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 3",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 4",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 5",
+                                  "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 6",
+                                  "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 7",
+                                  "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                },
+                              ]
+                            }
+                            style={
+                              Object {
+                                "font": "12px Arial",
+                              }
+                            }
+                            tileComponent={[Function]}
+                            tileWidth={20}
+                            width={500}
+                          >
+                            <div
+                              height={15}
+                              style={
+                                Object {
+                                  "font": "12px Arial",
+                                }
+                              }
+                            >
+                              <div
+                                style={
+                                  Object {
+                                    "overflow": "hidden",
+                                    "position": "relative",
+                                    "whiteSpace": "nowrap",
+                                    "width": 500,
+                                  }
+                                }
+                              >
+                                <ListComponent
+                                  componentCache={[Function]}
+                                  endTile={46}
+                                  maxWidth={900}
+                                  sequences={
+                                    Array [
+                                      Object {
+                                        "name": "sequence 1",
+                                        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                      },
+                                      Object {
+                                        "name": "sequence 2",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 3",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 4",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 5",
+                                        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 6",
+                                        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 7",
+                                        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                      },
+                                    ]
+                                  }
+                                  startTile={0}
+                                  tileComponent={[Function]}
+                                  tileWidth={20}
+                                >
+                                  <div>
+                                    <Marker
+                                      index={0}
+                                      key="0"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        1
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={1}
+                                      key="1"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={2}
+                                      key="2"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        3
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={3}
+                                      key="3"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={4}
+                                      key="4"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        5
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={5}
+                                      key="5"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={6}
+                                      key="6"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        7
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={7}
+                                      key="7"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={8}
+                                      key="8"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        9
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={9}
+                                      key="9"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={10}
+                                      key="10"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        11
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={11}
+                                      key="11"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={12}
+                                      key="12"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        13
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={13}
+                                      key="13"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={14}
+                                      key="14"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        15
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={15}
+                                      key="15"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={16}
+                                      key="16"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        17
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={17}
+                                      key="17"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={18}
+                                      key="18"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        19
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={19}
+                                      key="19"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={20}
+                                      key="20"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        21
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={21}
+                                      key="21"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={22}
+                                      key="22"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        23
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={23}
+                                      key="23"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={24}
+                                      key="24"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        25
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={25}
+                                      key="25"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={26}
+                                      key="26"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        27
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={27}
+                                      key="27"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={28}
+                                      key="28"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        29
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={29}
+                                      key="29"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={30}
+                                      key="30"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        31
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={31}
+                                      key="31"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={32}
+                                      key="32"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        33
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={33}
+                                      key="33"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={34}
+                                      key="34"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        35
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={35}
+                                      key="35"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={36}
+                                      key="36"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        37
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={37}
+                                      key="37"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={38}
+                                      key="38"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        39
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={39}
+                                      key="39"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={40}
+                                      key="40"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        41
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={41}
+                                      key="41"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={42}
+                                      key="42"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        43
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={43}
+                                      key="43"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={44}
+                                      key="44"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        45
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={45}
+                                      key="45"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                  </div>
+                                </ListComponent>
+                              </div>
+                            </div>
+                          </XBarComponent>
+                        </withPosition(XBarComponent)>
+                      </HTMLPositionBarComponent>
+                    </Connect(HTMLPositionBarComponent)>
+                  </div>
+                  <Connect(HTMLLabelsComponent)
+                    style={
+                      Object {
+                        "paddingTop": 20,
+                      }
+                    }
+                  >
+                    <HTMLLabelsComponent
+                      cacheElements={10}
+                      dispatch={[Function]}
+                      height={100}
+                      labelStyle={Object {}}
+                      nrYTiles={6}
+                      sequences={
+                        Array [
+                          Object {
+                            "name": "sequence 1",
+                            "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                          },
+                          Object {
+                            "name": "sequence 2",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 3",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 4",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 5",
+                            "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 6",
+                            "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 7",
+                            "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                          },
+                        ]
+                      }
                       style={
                         Object {
-                          "height": 10,
+                          "paddingTop": 20,
                         }
                       }
-                    />
-                  </div>
+                      tileHeight={20}
+                    >
+                      <withPosition(YBarComponent)
+                        cacheElements={10}
+                        componentCache={[Function]}
+                        height={100}
+                        nrYTiles={6}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        style={
+                          Object {
+                            "paddingTop": 20,
+                          }
+                        }
+                        tileComponent={[Function]}
+                        tileHeight={20}
+                      >
+                        <YBarComponent
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          height={100}
+                          nrYTiles={6}
+                          position={
+                            Object {
+                              "currentViewSequence": 0,
+                              "currentViewSequencePosition": 0,
+                              "lastCurrentViewSequence": 0,
+                              "lastStartYTile": 0,
+                              "xPos": 0,
+                              "xPosOffset": -0,
+                              "yPos": 0,
+                              "yPosOffset": -0,
+                            }
+                          }
+                          positionDispatch={[Function]}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          style={
+                            Object {
+                              "paddingTop": 20,
+                            }
+                          }
+                          tileComponent={[Function]}
+                          tileHeight={20}
+                        >
+                          <div
+                            style={
+                              Object {
+                                "paddingTop": 20,
+                              }
+                            }
+                          >
+                            <div
+                              style={
+                                Object {
+                                  "height": 100,
+                                  "overflow": "hidden",
+                                  "position": "relative",
+                                  "whiteSpace": "nowrap",
+                                }
+                              }
+                            >
+                              <ListComponent
+                                componentCache={[Function]}
+                                endTile={7}
+                                startTile={0}
+                                tileComponent={[Function]}
+                              >
+                                <div>
+                                  <Label
+                                    index={0}
+                                    key="0"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 1
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={1}
+                                    key="1"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 2
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={2}
+                                    key="2"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 3
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={3}
+                                    key="3"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 4
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={4}
+                                    key="4"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 5
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={5}
+                                    key="5"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 6
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={6}
+                                    key="6"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 7
+                                    </div>
+                                  </Label>
+                                </div>
+                              </ListComponent>
+                            </div>
+                          </div>
+                        </YBarComponent>
+                      </withPosition(YBarComponent)>
+                    </HTMLLabelsComponent>
+                  </Connect(HTMLLabelsComponent)>
                 </div>
-              </MSABasicLayout>
-            </Connect(MSABasicLayout)>
+              </MSAFunkyLayout>
+            </Connect(MSAFunkyLayout)>
           </div>
         </MSALayouter>
       </div>

--- a/src/components/layouts/__snapshots__/funky.test.js.snap
+++ b/src/components/layouts/__snapshots__/funky.test.js.snap
@@ -1,0 +1,2583 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders without crashing 1`] = `
+<PropsToReduxComponent
+  backgroundColor="red"
+  colorScheme="clustal"
+  engine="canvas"
+  height={100}
+  layout="funky"
+  sequences={
+    Array [
+      Object {
+        "name": "sequence 1",
+        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+      },
+      Object {
+        "name": "sequence 2",
+        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+      },
+      Object {
+        "name": "sequence 3",
+        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+      },
+      Object {
+        "name": "sequence 4",
+        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+      },
+      Object {
+        "name": "sequence 5",
+        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+      },
+      Object {
+        "name": "sequence 6",
+        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+      },
+      Object {
+        "name": "sequence 7",
+        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+      },
+    ]
+  }
+  tileHeight={20}
+  tileWidth={20}
+  width={500}
+>
+  <MSAViewerComponent
+    msaStore={
+      Object {
+        "dispatch": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+        Symbol(observable): [Function],
+      }
+    }
+  >
+    <Provider
+      store={
+        Object {
+          "dispatch": [Function],
+          "getState": [Function],
+          "replaceReducer": [Function],
+          "subscribe": [Function],
+          Symbol(observable): [Function],
+        }
+      }
+    >
+      <div>
+        <MSALayouter
+          layout="default"
+        >
+          <div>
+            <Connect(MSABasicLayout)
+              forwardedPropsKeys={
+                Array [
+                  "sequenceViewerProps",
+                  "labelsProps",
+                  "positionBarProps",
+                  "overviewBarProps",
+                ]
+              }
+            >
+              <MSABasicLayout
+                dispatch={[Function]}
+                forwardedPropsKeys={
+                  Array [
+                    "sequenceViewerProps",
+                    "labelsProps",
+                    "positionBarProps",
+                    "overviewBarProps",
+                  ]
+                }
+                tileHeight={20}
+              >
+                <div
+                  style={
+                    Object {
+                      "display": "flex",
+                    }
+                  }
+                >
+                  <Connect(HTMLLabelsComponent)
+                    style={
+                      Object {
+                        "paddingTop": 70,
+                      }
+                    }
+                  >
+                    <HTMLLabelsComponent
+                      cacheElements={10}
+                      dispatch={[Function]}
+                      height={100}
+                      labelStyle={Object {}}
+                      nrYTiles={6}
+                      sequences={
+                        Array [
+                          Object {
+                            "name": "sequence 1",
+                            "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                          },
+                          Object {
+                            "name": "sequence 2",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 3",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 4",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 5",
+                            "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 6",
+                            "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 7",
+                            "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                          },
+                        ]
+                      }
+                      style={
+                        Object {
+                          "paddingTop": 70,
+                        }
+                      }
+                      tileHeight={20}
+                    >
+                      <withPosition(YBarComponent)
+                        cacheElements={10}
+                        componentCache={[Function]}
+                        height={100}
+                        nrYTiles={6}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        style={
+                          Object {
+                            "paddingTop": 70,
+                          }
+                        }
+                        tileComponent={[Function]}
+                        tileHeight={20}
+                      >
+                        <YBarComponent
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          height={100}
+                          nrYTiles={6}
+                          position={
+                            Object {
+                              "currentViewSequence": 0,
+                              "currentViewSequencePosition": 0,
+                              "lastCurrentViewSequence": 0,
+                              "lastStartYTile": 0,
+                              "xPos": 0,
+                              "xPosOffset": -0,
+                              "yPos": 0,
+                              "yPosOffset": -0,
+                            }
+                          }
+                          positionDispatch={[Function]}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          style={
+                            Object {
+                              "paddingTop": 70,
+                            }
+                          }
+                          tileComponent={[Function]}
+                          tileHeight={20}
+                        >
+                          <div
+                            style={
+                              Object {
+                                "paddingTop": 70,
+                              }
+                            }
+                          >
+                            <div
+                              style={
+                                Object {
+                                  "height": 100,
+                                  "overflow": "hidden",
+                                  "position": "relative",
+                                  "whiteSpace": "nowrap",
+                                }
+                              }
+                            >
+                              <ListComponent
+                                componentCache={[Function]}
+                                endTile={7}
+                                startTile={0}
+                                tileComponent={[Function]}
+                              >
+                                <div>
+                                  <Label
+                                    index={0}
+                                    key="0"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 1
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={1}
+                                    key="1"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 2
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={2}
+                                    key="2"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 3
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={3}
+                                    key="3"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 4
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={4}
+                                    key="4"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 5
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={5}
+                                    key="5"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 6
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={6}
+                                    key="6"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 7
+                                    </div>
+                                  </Label>
+                                </div>
+                              </ListComponent>
+                            </div>
+                          </div>
+                        </YBarComponent>
+                      </withPosition(YBarComponent)>
+                    </HTMLLabelsComponent>
+                  </Connect(HTMLLabelsComponent)>
+                  <div>
+                    <Connect(HTMLOverviewBarComponent)
+                      height={50}
+                    >
+                      <HTMLOverviewBarComponent
+                        cacheElements={10}
+                        dispatch={[Function]}
+                        fillColor="#999999"
+                        height={50}
+                        maxLength={60}
+                        method="conservation"
+                        nrXTiles={26}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        tileWidth={20}
+                        width={500}
+                      >
+                        <withPosition(XBarComponent)
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          maxLength={60}
+                          nrXTiles={26}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          tileComponent={[Function]}
+                          tileWidth={20}
+                          width={500}
+                        >
+                          <XBarComponent
+                            cacheElements={10}
+                            componentCache={[Function]}
+                            maxLength={60}
+                            nrXTiles={26}
+                            position={
+                              Object {
+                                "currentViewSequence": 0,
+                                "currentViewSequencePosition": 0,
+                                "lastCurrentViewSequencePosition": 0,
+                                "lastStartXTile": 0,
+                                "xPos": 0,
+                                "xPosOffset": -0,
+                                "yPos": 0,
+                                "yPosOffset": -0,
+                              }
+                            }
+                            positionDispatch={[Function]}
+                            sequences={
+                              Array [
+                                Object {
+                                  "name": "sequence 1",
+                                  "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                },
+                                Object {
+                                  "name": "sequence 2",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 3",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 4",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 5",
+                                  "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 6",
+                                  "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 7",
+                                  "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                },
+                              ]
+                            }
+                            tileComponent={[Function]}
+                            tileWidth={20}
+                            width={500}
+                          >
+                            <div
+                              style={
+                                Object {
+                                  "height": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                style={
+                                  Object {
+                                    "overflow": "hidden",
+                                    "position": "relative",
+                                    "whiteSpace": "nowrap",
+                                    "width": 500,
+                                  }
+                                }
+                              >
+                                <ListComponent
+                                  componentCache={[Function]}
+                                  endTile={46}
+                                  maxWidth={900}
+                                  sequences={
+                                    Array [
+                                      Object {
+                                        "name": "sequence 1",
+                                        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                      },
+                                      Object {
+                                        "name": "sequence 2",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 3",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 4",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 5",
+                                        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 6",
+                                        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 7",
+                                        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                      },
+                                    ]
+                                  }
+                                  startTile={0}
+                                  tileComponent={[Function]}
+                                  tileWidth={20}
+                                >
+                                  <div>
+                                    <Bar
+                                      index={0}
+                                      key="0"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={1}
+                                      key="1"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={2}
+                                      key="2"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={3}
+                                      key="3"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={4}
+                                      key="4"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={5}
+                                      key="5"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 34,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={6}
+                                      key="6"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={7}
+                                      key="7"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 32,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={8}
+                                      key="8"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={9}
+                                      key="9"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={10}
+                                      key="10"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 28,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={11}
+                                      key="11"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 21,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={12}
+                                      key="12"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={13}
+                                      key="13"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={14}
+                                      key="14"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={15}
+                                      key="15"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={16}
+                                      key="16"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={17}
+                                      key="17"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={18}
+                                      key="18"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={19}
+                                      key="19"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={20}
+                                      key="20"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={21}
+                                      key="21"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={22}
+                                      key="22"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={23}
+                                      key="23"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={24}
+                                      key="24"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={25}
+                                      key="25"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={26}
+                                      key="26"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={27}
+                                      key="27"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={28}
+                                      key="28"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={29}
+                                      key="29"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={30}
+                                      key="30"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={31}
+                                      key="31"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={32}
+                                      key="32"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={33}
+                                      key="33"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={34}
+                                      key="34"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={35}
+                                      key="35"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={36}
+                                      key="36"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={37}
+                                      key="37"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={38}
+                                      key="38"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={39}
+                                      key="39"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={40}
+                                      key="40"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={41}
+                                      key="41"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={42}
+                                      key="42"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={43}
+                                      key="43"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={44}
+                                      key="44"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={45}
+                                      key="45"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                  </div>
+                                </ListComponent>
+                              </div>
+                            </div>
+                          </XBarComponent>
+                        </withPosition(XBarComponent)>
+                      </HTMLOverviewBarComponent>
+                    </Connect(HTMLOverviewBarComponent)>
+                    <Connect(HTMLPositionBarComponent)>
+                      <HTMLPositionBarComponent
+                        cacheElements={10}
+                        dispatch={[Function]}
+                        height={15}
+                        markerSteps={2}
+                        markerStyle={Object {}}
+                        maxLength={60}
+                        nrXTiles={26}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        startIndex={1}
+                        style={
+                          Object {
+                            "font": "12px Arial",
+                          }
+                        }
+                        tileWidth={20}
+                        width={500}
+                      >
+                        <withPosition(XBarComponent)
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          height={15}
+                          maxLength={60}
+                          nrXTiles={26}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          style={
+                            Object {
+                              "font": "12px Arial",
+                            }
+                          }
+                          tileComponent={[Function]}
+                          tileWidth={20}
+                          width={500}
+                        >
+                          <XBarComponent
+                            cacheElements={10}
+                            componentCache={[Function]}
+                            height={15}
+                            maxLength={60}
+                            nrXTiles={26}
+                            position={
+                              Object {
+                                "currentViewSequence": 0,
+                                "currentViewSequencePosition": 0,
+                                "lastCurrentViewSequencePosition": 0,
+                                "lastStartXTile": 0,
+                                "xPos": 0,
+                                "xPosOffset": -0,
+                                "yPos": 0,
+                                "yPosOffset": -0,
+                              }
+                            }
+                            positionDispatch={[Function]}
+                            sequences={
+                              Array [
+                                Object {
+                                  "name": "sequence 1",
+                                  "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                },
+                                Object {
+                                  "name": "sequence 2",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 3",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 4",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 5",
+                                  "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 6",
+                                  "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 7",
+                                  "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                },
+                              ]
+                            }
+                            style={
+                              Object {
+                                "font": "12px Arial",
+                              }
+                            }
+                            tileComponent={[Function]}
+                            tileWidth={20}
+                            width={500}
+                          >
+                            <div
+                              height={15}
+                              style={
+                                Object {
+                                  "font": "12px Arial",
+                                }
+                              }
+                            >
+                              <div
+                                style={
+                                  Object {
+                                    "overflow": "hidden",
+                                    "position": "relative",
+                                    "whiteSpace": "nowrap",
+                                    "width": 500,
+                                  }
+                                }
+                              >
+                                <ListComponent
+                                  componentCache={[Function]}
+                                  endTile={46}
+                                  maxWidth={900}
+                                  sequences={
+                                    Array [
+                                      Object {
+                                        "name": "sequence 1",
+                                        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                      },
+                                      Object {
+                                        "name": "sequence 2",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 3",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 4",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 5",
+                                        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 6",
+                                        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 7",
+                                        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                      },
+                                    ]
+                                  }
+                                  startTile={0}
+                                  tileComponent={[Function]}
+                                  tileWidth={20}
+                                >
+                                  <div>
+                                    <Marker
+                                      index={0}
+                                      key="0"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        1
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={1}
+                                      key="1"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={2}
+                                      key="2"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        3
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={3}
+                                      key="3"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={4}
+                                      key="4"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        5
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={5}
+                                      key="5"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={6}
+                                      key="6"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        7
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={7}
+                                      key="7"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={8}
+                                      key="8"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        9
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={9}
+                                      key="9"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={10}
+                                      key="10"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        11
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={11}
+                                      key="11"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={12}
+                                      key="12"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        13
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={13}
+                                      key="13"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={14}
+                                      key="14"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        15
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={15}
+                                      key="15"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={16}
+                                      key="16"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        17
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={17}
+                                      key="17"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={18}
+                                      key="18"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        19
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={19}
+                                      key="19"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={20}
+                                      key="20"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        21
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={21}
+                                      key="21"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={22}
+                                      key="22"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        23
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={23}
+                                      key="23"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={24}
+                                      key="24"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        25
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={25}
+                                      key="25"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={26}
+                                      key="26"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        27
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={27}
+                                      key="27"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={28}
+                                      key="28"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        29
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={29}
+                                      key="29"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={30}
+                                      key="30"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        31
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={31}
+                                      key="31"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={32}
+                                      key="32"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        33
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={33}
+                                      key="33"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={34}
+                                      key="34"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        35
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={35}
+                                      key="35"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={36}
+                                      key="36"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        37
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={37}
+                                      key="37"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={38}
+                                      key="38"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        39
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={39}
+                                      key="39"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={40}
+                                      key="40"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        41
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={41}
+                                      key="41"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={42}
+                                      key="42"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        43
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={43}
+                                      key="43"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={44}
+                                      key="44"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        45
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={45}
+                                      key="45"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                  </div>
+                                </ListComponent>
+                              </div>
+                            </div>
+                          </XBarComponent>
+                        </withPosition(XBarComponent)>
+                      </HTMLPositionBarComponent>
+                    </Connect(HTMLPositionBarComponent)>
+                    <Connect(withPosition(SequenceViewerComponent))>
+                      <withPosition(SequenceViewerComponent)
+                        colorScheme={
+                          ColorScheme {
+                            "scheme": StaticSchemeClass {
+                              "defaultColor": "#ffffff",
+                              "getColor": [Function],
+                              "map": Object {
+                                "A": "orange",
+                                "B": "#fff",
+                                "C": "green",
+                                "D": "red",
+                                "E": "red",
+                                "F": "blue",
+                                "G": "orange",
+                                "Gap": "#fff",
+                                "H": "red",
+                                "I": "green",
+                                "J": "#fff",
+                                "K": "red",
+                                "L": "green",
+                                "M": "green",
+                                "N": "#fff",
+                                "O": "#fff",
+                                "P": "orange",
+                                "Q": "#fff",
+                                "R": "red",
+                                "S": "orange",
+                                "T": "orange",
+                                "U": "#fff",
+                                "V": "green",
+                                "W": "blue",
+                                "X": "#fff",
+                                "Y": "blue",
+                                "Z": "#fff",
+                              },
+                              "type": "static",
+                            },
+                          }
+                        }
+                        dispatch={[Function]}
+                        fullHeight={140}
+                        fullWidth={1200}
+                        height={100}
+                        nrXTiles={26}
+                        nrYTiles={6}
+                        sequences={
+                          Object {
+                            "length": 7,
+                            "maxLength": 60,
+                            "raw": Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ],
+                          }
+                        }
+                        tileHeight={20}
+                        tileWidth={20}
+                        width={500}
+                      >
+                        <SequenceViewerComponent
+                          border={false}
+                          borderColor="black"
+                          borderWidth={1}
+                          cacheElements={20}
+                          colorScheme={
+                            ColorScheme {
+                              "scheme": StaticSchemeClass {
+                                "defaultColor": "#ffffff",
+                                "getColor": [Function],
+                                "map": Object {
+                                  "A": "orange",
+                                  "B": "#fff",
+                                  "C": "green",
+                                  "D": "red",
+                                  "E": "red",
+                                  "F": "blue",
+                                  "G": "orange",
+                                  "Gap": "#fff",
+                                  "H": "red",
+                                  "I": "green",
+                                  "J": "#fff",
+                                  "K": "red",
+                                  "L": "green",
+                                  "M": "green",
+                                  "N": "#fff",
+                                  "O": "#fff",
+                                  "P": "orange",
+                                  "Q": "#fff",
+                                  "R": "red",
+                                  "S": "orange",
+                                  "T": "orange",
+                                  "U": "#fff",
+                                  "V": "green",
+                                  "W": "blue",
+                                  "X": "#fff",
+                                  "Y": "blue",
+                                  "Z": "#fff",
+                                },
+                                "type": "static",
+                              },
+                            }
+                          }
+                          dispatch={[Function]}
+                          fullHeight={140}
+                          fullWidth={1200}
+                          height={100}
+                          nrXTiles={26}
+                          nrYTiles={6}
+                          overflow="hidden"
+                          overflowX="auto"
+                          overflowY="auto"
+                          position={
+                            Object {
+                              "currentViewSequence": 0,
+                              "currentViewSequencePosition": 0,
+                              "xPos": 0,
+                              "xPosOffset": -0,
+                              "yPos": 0,
+                              "yPosOffset": -0,
+                            }
+                          }
+                          positionDispatch={[Function]}
+                          scrollBarPositionX="bottom"
+                          scrollBarPositionY="right"
+                          sequences={
+                            Object {
+                              "length": 7,
+                              "maxLength": 60,
+                              "raw": Array [
+                                Object {
+                                  "name": "sequence 1",
+                                  "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                },
+                                Object {
+                                  "name": "sequence 2",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 3",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 4",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 5",
+                                  "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 6",
+                                  "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 7",
+                                  "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                },
+                              ],
+                            }
+                          }
+                          showModBar={false}
+                          textColor="black"
+                          textFont="18px Arial"
+                          tileHeight={20}
+                          tileWidth={20}
+                          width={500}
+                          xGridSize={10}
+                          yGridSize={10}
+                        >
+                          <div
+                            height={100}
+                            style={
+                              Object {
+                                "cursor": "grab",
+                                "height": 100,
+                                "position": "relative",
+                                "width": 500,
+                              }
+                            }
+                            width={500}
+                          >
+                            <canvas
+                              height={100}
+                              style={
+                                Object {
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "top": 0,
+                                }
+                              }
+                              width={500}
+                            >
+                              Your browser does not seem to support HTML5 canvas.
+                            </canvas>
+                            <canvas
+                              height={100}
+                              style={
+                                Object {
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "top": 0,
+                                }
+                              }
+                              width={500}
+                            >
+                              Your browser does not seem to support HTML5 canvas.
+                            </canvas>
+                            <withPosition(FakeScroll)
+                              fullHeight={140}
+                              fullWidth={1200}
+                              height={100}
+                              overflow="hidden"
+                              overflowX="auto"
+                              overflowY="auto"
+                              positionX="bottom"
+                              positionY="right"
+                              width={500}
+                            >
+                              <FakeScroll
+                                fullHeight={140}
+                                fullWidth={1200}
+                                height={100}
+                                overflow="hidden"
+                                overflowX="auto"
+                                overflowY="auto"
+                                position={
+                                  Object {
+                                    "currentViewSequence": 0,
+                                    "currentViewSequencePosition": 0,
+                                    "xPos": 0,
+                                    "xPosOffset": -0,
+                                    "yPos": 0,
+                                    "yPosOffset": -0,
+                                  }
+                                }
+                                positionDispatch={[Function]}
+                                positionX="bottom"
+                                positionY="right"
+                                scrollBarWidth={5}
+                                width={500}
+                              >
+                                <div />
+                              </FakeScroll>
+                            </withPosition(FakeScroll)>
+                          </div>
+                        </SequenceViewerComponent>
+                      </withPosition(SequenceViewerComponent)>
+                    </Connect(withPosition(SequenceViewerComponent))>
+                    <div
+                      style={
+                        Object {
+                          "height": 10,
+                        }
+                      }
+                    />
+                  </div>
+                </div>
+              </MSABasicLayout>
+            </Connect(MSABasicLayout)>
+          </div>
+        </MSALayouter>
+      </div>
+    </Provider>
+  </MSAViewerComponent>
+</PropsToReduxComponent>
+`;

--- a/src/components/layouts/__snapshots__/inverse.test.js.snap
+++ b/src/components/layouts/__snapshots__/inverse.test.js.snap
@@ -2,9 +2,7 @@
 
 exports[`renders without crashing 1`] = `
 <PropsToReduxComponent
-  backgroundColor="red"
   colorScheme="clustal"
-  engine="canvas"
   height={100}
   layout="inverse"
   sequences={
@@ -44,6 +42,7 @@ exports[`renders without crashing 1`] = `
   width={500}
 >
   <MSAViewerComponent
+    layout="inverse"
     msaStore={
       Object {
         "dispatch": [Function],
@@ -67,10 +66,11 @@ exports[`renders without crashing 1`] = `
     >
       <div>
         <MSALayouter
-          layout="default"
+          layout="inverse"
+          onResidueClick={[Function]}
         >
           <div>
-            <Connect(MSABasicLayout)
+            <Connect(MSAInverseLayout)
               forwardedPropsKeys={
                 Array [
                   "sequenceViewerProps",
@@ -80,7 +80,7 @@ exports[`renders without crashing 1`] = `
                 ]
               }
             >
-              <MSABasicLayout
+              <MSAInverseLayout
                 dispatch={[Function]}
                 forwardedPropsKeys={
                   Array [
@@ -99,291 +99,6 @@ exports[`renders without crashing 1`] = `
                     }
                   }
                 >
-                  <Connect(HTMLLabelsComponent)
-                    style={
-                      Object {
-                        "paddingTop": 70,
-                      }
-                    }
-                  >
-                    <HTMLLabelsComponent
-                      cacheElements={10}
-                      dispatch={[Function]}
-                      height={100}
-                      labelStyle={Object {}}
-                      nrYTiles={6}
-                      sequences={
-                        Array [
-                          Object {
-                            "name": "sequence 1",
-                            "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                          },
-                          Object {
-                            "name": "sequence 2",
-                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                          },
-                          Object {
-                            "name": "sequence 3",
-                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                          },
-                          Object {
-                            "name": "sequence 4",
-                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                          },
-                          Object {
-                            "name": "sequence 5",
-                            "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                          },
-                          Object {
-                            "name": "sequence 6",
-                            "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                          },
-                          Object {
-                            "name": "sequence 7",
-                            "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                          },
-                        ]
-                      }
-                      style={
-                        Object {
-                          "paddingTop": 70,
-                        }
-                      }
-                      tileHeight={20}
-                    >
-                      <withPosition(YBarComponent)
-                        cacheElements={10}
-                        componentCache={[Function]}
-                        height={100}
-                        nrYTiles={6}
-                        sequences={
-                          Array [
-                            Object {
-                              "name": "sequence 1",
-                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                            },
-                            Object {
-                              "name": "sequence 2",
-                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 3",
-                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 4",
-                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 5",
-                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 6",
-                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                            },
-                            Object {
-                              "name": "sequence 7",
-                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                            },
-                          ]
-                        }
-                        style={
-                          Object {
-                            "paddingTop": 70,
-                          }
-                        }
-                        tileComponent={[Function]}
-                        tileHeight={20}
-                      >
-                        <YBarComponent
-                          cacheElements={10}
-                          componentCache={[Function]}
-                          height={100}
-                          nrYTiles={6}
-                          position={
-                            Object {
-                              "currentViewSequence": 0,
-                              "currentViewSequencePosition": 0,
-                              "lastCurrentViewSequence": 0,
-                              "lastStartYTile": 0,
-                              "xPos": 0,
-                              "xPosOffset": -0,
-                              "yPos": 0,
-                              "yPosOffset": -0,
-                            }
-                          }
-                          positionDispatch={[Function]}
-                          sequences={
-                            Array [
-                              Object {
-                                "name": "sequence 1",
-                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
-                              },
-                              Object {
-                                "name": "sequence 2",
-                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                              },
-                              Object {
-                                "name": "sequence 3",
-                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                              },
-                              Object {
-                                "name": "sequence 4",
-                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                              },
-                              Object {
-                                "name": "sequence 5",
-                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                              },
-                              Object {
-                                "name": "sequence 6",
-                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
-                              },
-                              Object {
-                                "name": "sequence 7",
-                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
-                              },
-                            ]
-                          }
-                          style={
-                            Object {
-                              "paddingTop": 70,
-                            }
-                          }
-                          tileComponent={[Function]}
-                          tileHeight={20}
-                        >
-                          <div
-                            style={
-                              Object {
-                                "paddingTop": 70,
-                              }
-                            }
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "height": 100,
-                                  "overflow": "hidden",
-                                  "position": "relative",
-                                  "whiteSpace": "nowrap",
-                                }
-                              }
-                            >
-                              <ListComponent
-                                componentCache={[Function]}
-                                endTile={7}
-                                startTile={0}
-                                tileComponent={[Function]}
-                              >
-                                <div>
-                                  <Label
-                                    index={0}
-                                    key="0"
-                                  >
-                                    <div
-                                      style={
-                                        Object {
-                                          "height": 20,
-                                        }
-                                      }
-                                    >
-                                      sequence 1
-                                    </div>
-                                  </Label>
-                                  <Label
-                                    index={1}
-                                    key="1"
-                                  >
-                                    <div
-                                      style={
-                                        Object {
-                                          "height": 20,
-                                        }
-                                      }
-                                    >
-                                      sequence 2
-                                    </div>
-                                  </Label>
-                                  <Label
-                                    index={2}
-                                    key="2"
-                                  >
-                                    <div
-                                      style={
-                                        Object {
-                                          "height": 20,
-                                        }
-                                      }
-                                    >
-                                      sequence 3
-                                    </div>
-                                  </Label>
-                                  <Label
-                                    index={3}
-                                    key="3"
-                                  >
-                                    <div
-                                      style={
-                                        Object {
-                                          "height": 20,
-                                        }
-                                      }
-                                    >
-                                      sequence 4
-                                    </div>
-                                  </Label>
-                                  <Label
-                                    index={4}
-                                    key="4"
-                                  >
-                                    <div
-                                      style={
-                                        Object {
-                                          "height": 20,
-                                        }
-                                      }
-                                    >
-                                      sequence 5
-                                    </div>
-                                  </Label>
-                                  <Label
-                                    index={5}
-                                    key="5"
-                                  >
-                                    <div
-                                      style={
-                                        Object {
-                                          "height": 20,
-                                        }
-                                      }
-                                    >
-                                      sequence 6
-                                    </div>
-                                  </Label>
-                                  <Label
-                                    index={6}
-                                    key="6"
-                                  >
-                                    <div
-                                      style={
-                                        Object {
-                                          "height": 20,
-                                        }
-                                      }
-                                    >
-                                      sequence 7
-                                    </div>
-                                  </Label>
-                                </div>
-                              </ListComponent>
-                            </div>
-                          </div>
-                        </YBarComponent>
-                      </withPosition(YBarComponent)>
-                    </HTMLLabelsComponent>
-                  </Connect(HTMLLabelsComponent)>
                   <div>
                     <Connect(HTMLOverviewBarComponent)
                       height={50}
@@ -2563,17 +2278,295 @@ exports[`renders without crashing 1`] = `
                         </SequenceViewerComponent>
                       </withPosition(SequenceViewerComponent)>
                     </Connect(withPosition(SequenceViewerComponent))>
-                    <div
+                  </div>
+                  <Connect(HTMLLabelsComponent)
+                    style={
+                      Object {
+                        "paddingTop": 70,
+                      }
+                    }
+                  >
+                    <HTMLLabelsComponent
+                      cacheElements={10}
+                      dispatch={[Function]}
+                      height={100}
+                      labelStyle={Object {}}
+                      nrYTiles={6}
+                      sequences={
+                        Array [
+                          Object {
+                            "name": "sequence 1",
+                            "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                          },
+                          Object {
+                            "name": "sequence 2",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 3",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 4",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 5",
+                            "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 6",
+                            "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 7",
+                            "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                          },
+                        ]
+                      }
                       style={
                         Object {
-                          "height": 10,
+                          "paddingTop": 70,
                         }
                       }
-                    />
-                  </div>
+                      tileHeight={20}
+                    >
+                      <withPosition(YBarComponent)
+                        cacheElements={10}
+                        componentCache={[Function]}
+                        height={100}
+                        nrYTiles={6}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        style={
+                          Object {
+                            "paddingTop": 70,
+                          }
+                        }
+                        tileComponent={[Function]}
+                        tileHeight={20}
+                      >
+                        <YBarComponent
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          height={100}
+                          nrYTiles={6}
+                          position={
+                            Object {
+                              "currentViewSequence": 0,
+                              "currentViewSequencePosition": 0,
+                              "lastCurrentViewSequence": 0,
+                              "lastStartYTile": 0,
+                              "xPos": 0,
+                              "xPosOffset": -0,
+                              "yPos": 0,
+                              "yPosOffset": -0,
+                            }
+                          }
+                          positionDispatch={[Function]}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          style={
+                            Object {
+                              "paddingTop": 70,
+                            }
+                          }
+                          tileComponent={[Function]}
+                          tileHeight={20}
+                        >
+                          <div
+                            style={
+                              Object {
+                                "paddingTop": 70,
+                              }
+                            }
+                          >
+                            <div
+                              style={
+                                Object {
+                                  "height": 100,
+                                  "overflow": "hidden",
+                                  "position": "relative",
+                                  "whiteSpace": "nowrap",
+                                }
+                              }
+                            >
+                              <ListComponent
+                                componentCache={[Function]}
+                                endTile={7}
+                                startTile={0}
+                                tileComponent={[Function]}
+                              >
+                                <div>
+                                  <Label
+                                    index={0}
+                                    key="0"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 1
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={1}
+                                    key="1"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 2
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={2}
+                                    key="2"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 3
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={3}
+                                    key="3"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 4
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={4}
+                                    key="4"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 5
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={5}
+                                    key="5"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 6
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={6}
+                                    key="6"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 7
+                                    </div>
+                                  </Label>
+                                </div>
+                              </ListComponent>
+                            </div>
+                          </div>
+                        </YBarComponent>
+                      </withPosition(YBarComponent)>
+                    </HTMLLabelsComponent>
+                  </Connect(HTMLLabelsComponent)>
                 </div>
-              </MSABasicLayout>
-            </Connect(MSABasicLayout)>
+              </MSAInverseLayout>
+            </Connect(MSAInverseLayout)>
           </div>
         </MSALayouter>
       </div>

--- a/src/components/layouts/__snapshots__/inverse.test.js.snap
+++ b/src/components/layouts/__snapshots__/inverse.test.js.snap
@@ -1,0 +1,2583 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders without crashing 1`] = `
+<PropsToReduxComponent
+  backgroundColor="red"
+  colorScheme="clustal"
+  engine="canvas"
+  height={100}
+  layout="inverse"
+  sequences={
+    Array [
+      Object {
+        "name": "sequence 1",
+        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+      },
+      Object {
+        "name": "sequence 2",
+        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+      },
+      Object {
+        "name": "sequence 3",
+        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+      },
+      Object {
+        "name": "sequence 4",
+        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+      },
+      Object {
+        "name": "sequence 5",
+        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+      },
+      Object {
+        "name": "sequence 6",
+        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+      },
+      Object {
+        "name": "sequence 7",
+        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+      },
+    ]
+  }
+  tileHeight={20}
+  tileWidth={20}
+  width={500}
+>
+  <MSAViewerComponent
+    msaStore={
+      Object {
+        "dispatch": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+        Symbol(observable): [Function],
+      }
+    }
+  >
+    <Provider
+      store={
+        Object {
+          "dispatch": [Function],
+          "getState": [Function],
+          "replaceReducer": [Function],
+          "subscribe": [Function],
+          Symbol(observable): [Function],
+        }
+      }
+    >
+      <div>
+        <MSALayouter
+          layout="default"
+        >
+          <div>
+            <Connect(MSABasicLayout)
+              forwardedPropsKeys={
+                Array [
+                  "sequenceViewerProps",
+                  "labelsProps",
+                  "positionBarProps",
+                  "overviewBarProps",
+                ]
+              }
+            >
+              <MSABasicLayout
+                dispatch={[Function]}
+                forwardedPropsKeys={
+                  Array [
+                    "sequenceViewerProps",
+                    "labelsProps",
+                    "positionBarProps",
+                    "overviewBarProps",
+                  ]
+                }
+                tileHeight={20}
+              >
+                <div
+                  style={
+                    Object {
+                      "display": "flex",
+                    }
+                  }
+                >
+                  <Connect(HTMLLabelsComponent)
+                    style={
+                      Object {
+                        "paddingTop": 70,
+                      }
+                    }
+                  >
+                    <HTMLLabelsComponent
+                      cacheElements={10}
+                      dispatch={[Function]}
+                      height={100}
+                      labelStyle={Object {}}
+                      nrYTiles={6}
+                      sequences={
+                        Array [
+                          Object {
+                            "name": "sequence 1",
+                            "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                          },
+                          Object {
+                            "name": "sequence 2",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 3",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 4",
+                            "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 5",
+                            "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 6",
+                            "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                          },
+                          Object {
+                            "name": "sequence 7",
+                            "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                          },
+                        ]
+                      }
+                      style={
+                        Object {
+                          "paddingTop": 70,
+                        }
+                      }
+                      tileHeight={20}
+                    >
+                      <withPosition(YBarComponent)
+                        cacheElements={10}
+                        componentCache={[Function]}
+                        height={100}
+                        nrYTiles={6}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        style={
+                          Object {
+                            "paddingTop": 70,
+                          }
+                        }
+                        tileComponent={[Function]}
+                        tileHeight={20}
+                      >
+                        <YBarComponent
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          height={100}
+                          nrYTiles={6}
+                          position={
+                            Object {
+                              "currentViewSequence": 0,
+                              "currentViewSequencePosition": 0,
+                              "lastCurrentViewSequence": 0,
+                              "lastStartYTile": 0,
+                              "xPos": 0,
+                              "xPosOffset": -0,
+                              "yPos": 0,
+                              "yPosOffset": -0,
+                            }
+                          }
+                          positionDispatch={[Function]}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          style={
+                            Object {
+                              "paddingTop": 70,
+                            }
+                          }
+                          tileComponent={[Function]}
+                          tileHeight={20}
+                        >
+                          <div
+                            style={
+                              Object {
+                                "paddingTop": 70,
+                              }
+                            }
+                          >
+                            <div
+                              style={
+                                Object {
+                                  "height": 100,
+                                  "overflow": "hidden",
+                                  "position": "relative",
+                                  "whiteSpace": "nowrap",
+                                }
+                              }
+                            >
+                              <ListComponent
+                                componentCache={[Function]}
+                                endTile={7}
+                                startTile={0}
+                                tileComponent={[Function]}
+                              >
+                                <div>
+                                  <Label
+                                    index={0}
+                                    key="0"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 1
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={1}
+                                    key="1"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 2
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={2}
+                                    key="2"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 3
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={3}
+                                    key="3"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 4
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={4}
+                                    key="4"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 5
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={5}
+                                    key="5"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 6
+                                    </div>
+                                  </Label>
+                                  <Label
+                                    index={6}
+                                    key="6"
+                                  >
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 20,
+                                        }
+                                      }
+                                    >
+                                      sequence 7
+                                    </div>
+                                  </Label>
+                                </div>
+                              </ListComponent>
+                            </div>
+                          </div>
+                        </YBarComponent>
+                      </withPosition(YBarComponent)>
+                    </HTMLLabelsComponent>
+                  </Connect(HTMLLabelsComponent)>
+                  <div>
+                    <Connect(HTMLOverviewBarComponent)
+                      height={50}
+                    >
+                      <HTMLOverviewBarComponent
+                        cacheElements={10}
+                        dispatch={[Function]}
+                        fillColor="#999999"
+                        height={50}
+                        maxLength={60}
+                        method="conservation"
+                        nrXTiles={26}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        tileWidth={20}
+                        width={500}
+                      >
+                        <withPosition(XBarComponent)
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          maxLength={60}
+                          nrXTiles={26}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          tileComponent={[Function]}
+                          tileWidth={20}
+                          width={500}
+                        >
+                          <XBarComponent
+                            cacheElements={10}
+                            componentCache={[Function]}
+                            maxLength={60}
+                            nrXTiles={26}
+                            position={
+                              Object {
+                                "currentViewSequence": 0,
+                                "currentViewSequencePosition": 0,
+                                "lastCurrentViewSequencePosition": 0,
+                                "lastStartXTile": 0,
+                                "xPos": 0,
+                                "xPosOffset": -0,
+                                "yPos": 0,
+                                "yPosOffset": -0,
+                              }
+                            }
+                            positionDispatch={[Function]}
+                            sequences={
+                              Array [
+                                Object {
+                                  "name": "sequence 1",
+                                  "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                },
+                                Object {
+                                  "name": "sequence 2",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 3",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 4",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 5",
+                                  "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 6",
+                                  "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 7",
+                                  "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                },
+                              ]
+                            }
+                            tileComponent={[Function]}
+                            tileWidth={20}
+                            width={500}
+                          >
+                            <div
+                              style={
+                                Object {
+                                  "height": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                style={
+                                  Object {
+                                    "overflow": "hidden",
+                                    "position": "relative",
+                                    "whiteSpace": "nowrap",
+                                    "width": 500,
+                                  }
+                                }
+                              >
+                                <ListComponent
+                                  componentCache={[Function]}
+                                  endTile={46}
+                                  maxWidth={900}
+                                  sequences={
+                                    Array [
+                                      Object {
+                                        "name": "sequence 1",
+                                        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                      },
+                                      Object {
+                                        "name": "sequence 2",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 3",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 4",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 5",
+                                        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 6",
+                                        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 7",
+                                        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                      },
+                                    ]
+                                  }
+                                  startTile={0}
+                                  tileComponent={[Function]}
+                                  tileWidth={20}
+                                >
+                                  <div>
+                                    <Bar
+                                      index={0}
+                                      key="0"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={1}
+                                      key="1"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={2}
+                                      key="2"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={3}
+                                      key="3"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={4}
+                                      key="4"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={5}
+                                      key="5"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 34,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={6}
+                                      key="6"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={7}
+                                      key="7"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 32,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={8}
+                                      key="8"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={9}
+                                      key="9"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={10}
+                                      key="10"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 28,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={11}
+                                      key="11"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 21,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={12}
+                                      key="12"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={13}
+                                      key="13"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={14}
+                                      key="14"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={15}
+                                      key="15"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={16}
+                                      key="16"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={17}
+                                      key="17"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={18}
+                                      key="18"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={19}
+                                      key="19"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={20}
+                                      key="20"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={21}
+                                      key="21"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={22}
+                                      key="22"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={23}
+                                      key="23"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={24}
+                                      key="24"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={25}
+                                      key="25"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={26}
+                                      key="26"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={27}
+                                      key="27"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={28}
+                                      key="28"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={29}
+                                      key="29"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={30}
+                                      key="30"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={31}
+                                      key="31"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={32}
+                                      key="32"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={33}
+                                      key="33"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={34}
+                                      key="34"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={35}
+                                      key="35"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={36}
+                                      key="36"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={37}
+                                      key="37"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={38}
+                                      key="38"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={39}
+                                      key="39"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={40}
+                                      key="40"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={41}
+                                      key="41"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={42}
+                                      key="42"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={43}
+                                      key="43"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={44}
+                                      key="44"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 35,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                    <Bar
+                                      index={45}
+                                      key="45"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "backgroundColor": "#999999",
+                                            "display": "inline-block",
+                                            "height": 50,
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      />
+                                    </Bar>
+                                  </div>
+                                </ListComponent>
+                              </div>
+                            </div>
+                          </XBarComponent>
+                        </withPosition(XBarComponent)>
+                      </HTMLOverviewBarComponent>
+                    </Connect(HTMLOverviewBarComponent)>
+                    <Connect(HTMLPositionBarComponent)>
+                      <HTMLPositionBarComponent
+                        cacheElements={10}
+                        dispatch={[Function]}
+                        height={15}
+                        markerSteps={2}
+                        markerStyle={Object {}}
+                        maxLength={60}
+                        nrXTiles={26}
+                        sequences={
+                          Array [
+                            Object {
+                              "name": "sequence 1",
+                              "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                            },
+                            Object {
+                              "name": "sequence 2",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 3",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 4",
+                              "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 5",
+                              "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 6",
+                              "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                            },
+                            Object {
+                              "name": "sequence 7",
+                              "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                            },
+                          ]
+                        }
+                        startIndex={1}
+                        style={
+                          Object {
+                            "font": "12px Arial",
+                          }
+                        }
+                        tileWidth={20}
+                        width={500}
+                      >
+                        <withPosition(XBarComponent)
+                          cacheElements={10}
+                          componentCache={[Function]}
+                          height={15}
+                          maxLength={60}
+                          nrXTiles={26}
+                          sequences={
+                            Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ]
+                          }
+                          style={
+                            Object {
+                              "font": "12px Arial",
+                            }
+                          }
+                          tileComponent={[Function]}
+                          tileWidth={20}
+                          width={500}
+                        >
+                          <XBarComponent
+                            cacheElements={10}
+                            componentCache={[Function]}
+                            height={15}
+                            maxLength={60}
+                            nrXTiles={26}
+                            position={
+                              Object {
+                                "currentViewSequence": 0,
+                                "currentViewSequencePosition": 0,
+                                "lastCurrentViewSequencePosition": 0,
+                                "lastStartXTile": 0,
+                                "xPos": 0,
+                                "xPosOffset": -0,
+                                "yPos": 0,
+                                "yPosOffset": -0,
+                              }
+                            }
+                            positionDispatch={[Function]}
+                            sequences={
+                              Array [
+                                Object {
+                                  "name": "sequence 1",
+                                  "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                },
+                                Object {
+                                  "name": "sequence 2",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 3",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 4",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 5",
+                                  "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 6",
+                                  "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 7",
+                                  "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                },
+                              ]
+                            }
+                            style={
+                              Object {
+                                "font": "12px Arial",
+                              }
+                            }
+                            tileComponent={[Function]}
+                            tileWidth={20}
+                            width={500}
+                          >
+                            <div
+                              height={15}
+                              style={
+                                Object {
+                                  "font": "12px Arial",
+                                }
+                              }
+                            >
+                              <div
+                                style={
+                                  Object {
+                                    "overflow": "hidden",
+                                    "position": "relative",
+                                    "whiteSpace": "nowrap",
+                                    "width": 500,
+                                  }
+                                }
+                              >
+                                <ListComponent
+                                  componentCache={[Function]}
+                                  endTile={46}
+                                  maxWidth={900}
+                                  sequences={
+                                    Array [
+                                      Object {
+                                        "name": "sequence 1",
+                                        "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                      },
+                                      Object {
+                                        "name": "sequence 2",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 3",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 4",
+                                        "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 5",
+                                        "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 6",
+                                        "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                      },
+                                      Object {
+                                        "name": "sequence 7",
+                                        "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                      },
+                                    ]
+                                  }
+                                  startTile={0}
+                                  tileComponent={[Function]}
+                                  tileWidth={20}
+                                >
+                                  <div>
+                                    <Marker
+                                      index={0}
+                                      key="0"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        1
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={1}
+                                      key="1"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={2}
+                                      key="2"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        3
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={3}
+                                      key="3"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={4}
+                                      key="4"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        5
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={5}
+                                      key="5"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={6}
+                                      key="6"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        7
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={7}
+                                      key="7"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={8}
+                                      key="8"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        9
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={9}
+                                      key="9"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={10}
+                                      key="10"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        11
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={11}
+                                      key="11"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={12}
+                                      key="12"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        13
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={13}
+                                      key="13"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={14}
+                                      key="14"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        15
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={15}
+                                      key="15"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={16}
+                                      key="16"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        17
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={17}
+                                      key="17"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={18}
+                                      key="18"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        19
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={19}
+                                      key="19"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={20}
+                                      key="20"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        21
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={21}
+                                      key="21"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={22}
+                                      key="22"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        23
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={23}
+                                      key="23"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={24}
+                                      key="24"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        25
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={25}
+                                      key="25"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={26}
+                                      key="26"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        27
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={27}
+                                      key="27"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={28}
+                                      key="28"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        29
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={29}
+                                      key="29"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={30}
+                                      key="30"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        31
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={31}
+                                      key="31"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={32}
+                                      key="32"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        33
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={33}
+                                      key="33"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={34}
+                                      key="34"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        35
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={35}
+                                      key="35"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={36}
+                                      key="36"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        37
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={37}
+                                      key="37"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={38}
+                                      key="38"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        39
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={39}
+                                      key="39"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={40}
+                                      key="40"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        41
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={41}
+                                      key="41"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={42}
+                                      key="42"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        43
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={43}
+                                      key="43"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={44}
+                                      key="44"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        45
+                                      </div>
+                                    </Marker>
+                                    <Marker
+                                      index={45}
+                                      key="45"
+                                    >
+                                      <div
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                            "textAlign": "center",
+                                            "width": 20,
+                                          }
+                                        }
+                                      >
+                                        .
+                                      </div>
+                                    </Marker>
+                                  </div>
+                                </ListComponent>
+                              </div>
+                            </div>
+                          </XBarComponent>
+                        </withPosition(XBarComponent)>
+                      </HTMLPositionBarComponent>
+                    </Connect(HTMLPositionBarComponent)>
+                    <Connect(withPosition(SequenceViewerComponent))>
+                      <withPosition(SequenceViewerComponent)
+                        colorScheme={
+                          ColorScheme {
+                            "scheme": StaticSchemeClass {
+                              "defaultColor": "#ffffff",
+                              "getColor": [Function],
+                              "map": Object {
+                                "A": "orange",
+                                "B": "#fff",
+                                "C": "green",
+                                "D": "red",
+                                "E": "red",
+                                "F": "blue",
+                                "G": "orange",
+                                "Gap": "#fff",
+                                "H": "red",
+                                "I": "green",
+                                "J": "#fff",
+                                "K": "red",
+                                "L": "green",
+                                "M": "green",
+                                "N": "#fff",
+                                "O": "#fff",
+                                "P": "orange",
+                                "Q": "#fff",
+                                "R": "red",
+                                "S": "orange",
+                                "T": "orange",
+                                "U": "#fff",
+                                "V": "green",
+                                "W": "blue",
+                                "X": "#fff",
+                                "Y": "blue",
+                                "Z": "#fff",
+                              },
+                              "type": "static",
+                            },
+                          }
+                        }
+                        dispatch={[Function]}
+                        fullHeight={140}
+                        fullWidth={1200}
+                        height={100}
+                        nrXTiles={26}
+                        nrYTiles={6}
+                        sequences={
+                          Object {
+                            "length": 7,
+                            "maxLength": 60,
+                            "raw": Array [
+                              Object {
+                                "name": "sequence 1",
+                                "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                              },
+                              Object {
+                                "name": "sequence 2",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 3",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 4",
+                                "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 5",
+                                "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 6",
+                                "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                              },
+                              Object {
+                                "name": "sequence 7",
+                                "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                              },
+                            ],
+                          }
+                        }
+                        tileHeight={20}
+                        tileWidth={20}
+                        width={500}
+                      >
+                        <SequenceViewerComponent
+                          border={false}
+                          borderColor="black"
+                          borderWidth={1}
+                          cacheElements={20}
+                          colorScheme={
+                            ColorScheme {
+                              "scheme": StaticSchemeClass {
+                                "defaultColor": "#ffffff",
+                                "getColor": [Function],
+                                "map": Object {
+                                  "A": "orange",
+                                  "B": "#fff",
+                                  "C": "green",
+                                  "D": "red",
+                                  "E": "red",
+                                  "F": "blue",
+                                  "G": "orange",
+                                  "Gap": "#fff",
+                                  "H": "red",
+                                  "I": "green",
+                                  "J": "#fff",
+                                  "K": "red",
+                                  "L": "green",
+                                  "M": "green",
+                                  "N": "#fff",
+                                  "O": "#fff",
+                                  "P": "orange",
+                                  "Q": "#fff",
+                                  "R": "red",
+                                  "S": "orange",
+                                  "T": "orange",
+                                  "U": "#fff",
+                                  "V": "green",
+                                  "W": "blue",
+                                  "X": "#fff",
+                                  "Y": "blue",
+                                  "Z": "#fff",
+                                },
+                                "type": "static",
+                              },
+                            }
+                          }
+                          dispatch={[Function]}
+                          fullHeight={140}
+                          fullWidth={1200}
+                          height={100}
+                          nrXTiles={26}
+                          nrYTiles={6}
+                          overflow="hidden"
+                          overflowX="auto"
+                          overflowY="auto"
+                          position={
+                            Object {
+                              "currentViewSequence": 0,
+                              "currentViewSequencePosition": 0,
+                              "xPos": 0,
+                              "xPosOffset": -0,
+                              "yPos": 0,
+                              "yPosOffset": -0,
+                            }
+                          }
+                          positionDispatch={[Function]}
+                          scrollBarPositionX="bottom"
+                          scrollBarPositionY="right"
+                          sequences={
+                            Object {
+                              "length": 7,
+                              "maxLength": 60,
+                              "raw": Array [
+                                Object {
+                                  "name": "sequence 1",
+                                  "sequence": "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+                                },
+                                Object {
+                                  "name": "sequence 2",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 3",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 4",
+                                  "sequence": "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 5",
+                                  "sequence": "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 6",
+                                  "sequence": "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+                                },
+                                Object {
+                                  "name": "sequence 7",
+                                  "sequence": "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+                                },
+                              ],
+                            }
+                          }
+                          showModBar={false}
+                          textColor="black"
+                          textFont="18px Arial"
+                          tileHeight={20}
+                          tileWidth={20}
+                          width={500}
+                          xGridSize={10}
+                          yGridSize={10}
+                        >
+                          <div
+                            height={100}
+                            style={
+                              Object {
+                                "cursor": "grab",
+                                "height": 100,
+                                "position": "relative",
+                                "width": 500,
+                              }
+                            }
+                            width={500}
+                          >
+                            <canvas
+                              height={100}
+                              style={
+                                Object {
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "top": 0,
+                                }
+                              }
+                              width={500}
+                            >
+                              Your browser does not seem to support HTML5 canvas.
+                            </canvas>
+                            <canvas
+                              height={100}
+                              style={
+                                Object {
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "top": 0,
+                                }
+                              }
+                              width={500}
+                            >
+                              Your browser does not seem to support HTML5 canvas.
+                            </canvas>
+                            <withPosition(FakeScroll)
+                              fullHeight={140}
+                              fullWidth={1200}
+                              height={100}
+                              overflow="hidden"
+                              overflowX="auto"
+                              overflowY="auto"
+                              positionX="bottom"
+                              positionY="right"
+                              width={500}
+                            >
+                              <FakeScroll
+                                fullHeight={140}
+                                fullWidth={1200}
+                                height={100}
+                                overflow="hidden"
+                                overflowX="auto"
+                                overflowY="auto"
+                                position={
+                                  Object {
+                                    "currentViewSequence": 0,
+                                    "currentViewSequencePosition": 0,
+                                    "xPos": 0,
+                                    "xPosOffset": -0,
+                                    "yPos": 0,
+                                    "yPosOffset": -0,
+                                  }
+                                }
+                                positionDispatch={[Function]}
+                                positionX="bottom"
+                                positionY="right"
+                                scrollBarWidth={5}
+                                width={500}
+                              >
+                                <div />
+                              </FakeScroll>
+                            </withPosition(FakeScroll)>
+                          </div>
+                        </SequenceViewerComponent>
+                      </withPosition(SequenceViewerComponent)>
+                    </Connect(withPosition(SequenceViewerComponent))>
+                    <div
+                      style={
+                        Object {
+                          "height": 10,
+                        }
+                      }
+                    />
+                  </div>
+                </div>
+              </MSABasicLayout>
+            </Connect(MSABasicLayout)>
+          </div>
+        </MSALayouter>
+      </div>
+    </Provider>
+  </MSAViewerComponent>
+</PropsToReduxComponent>
+`;

--- a/src/components/layouts/basic.js
+++ b/src/components/layouts/basic.js
@@ -41,12 +41,8 @@ class MSABasicLayout extends PureBaseLayout {
           <OverviewBar height={overviewBarHeight}
             {...this.props.overviewBarProps}
           />
-          <PositionBar
-            {...this.props.positionBarProps}
-          />
-          <SequenceViewer
-            {...this.props.sequenceViewerProps}
-          />
+          <PositionBar {...this.props.positionBarProps} />
+          <SequenceViewer {...this.props.sequenceViewerProps} />
           <div style={separatorPadding} />
         </div>
       </div>

--- a/src/components/layouts/basic.js
+++ b/src/components/layouts/basic.js
@@ -1,0 +1,69 @@
+/**
+* Copyright 2018, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+import React from 'react';
+
+import {
+  Labels,
+  OverviewBar,
+  PositionBar,
+  SequenceViewer,
+} from '../index';
+
+import PureBaseLayout from './PureBaseLayout';
+import msaConnect from '../../store/connect';
+
+class MSABasicLayout extends PureBaseLayout {
+  render() {
+    const labelsPadding = this.props.tileHeight;
+    const overviewBarHeight = 50;
+    const labelsAndSequenceDiv = {
+      display: "flex",
+    };
+    const labelsStyle = {
+      paddingTop: labelsPadding + overviewBarHeight,
+    }
+    const separatorPadding = {
+      height: 10,
+    };
+    return (
+      <div style={labelsAndSequenceDiv}>
+        <Labels
+          style={labelsStyle}
+            {...this.props.labelsProps}
+        />
+        <div>
+          <OverviewBar height={overviewBarHeight}
+            {...this.props.overviewBarProps}
+          />
+          <PositionBar
+            {...this.props.positionBarProps}
+          />
+          <SequenceViewer
+            {...this.props.sequenceViewerProps}
+          />
+          <div style={separatorPadding} />
+        </div>
+      </div>
+    );
+    //<SequenceOverview />
+  }
+}
+MSABasicLayout.propTypes = {
+  ...PureBaseLayout.propTypes,
+};
+
+const mapStateToProps = state => {
+  return {
+    tileHeight: state.props.tileHeight,
+  }
+}
+
+export default msaConnect(
+  mapStateToProps,
+)(MSABasicLayout);

--- a/src/components/layouts/basic.test.js
+++ b/src/components/layouts/basic.test.js
@@ -1,0 +1,21 @@
+/**
+* Copyright 2018, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+import React from 'react';
+import MSAViewer from '../MSAViewer';
+import dummySequences from '../../test/dummySequences';
+
+import {
+  mount
+} from 'enzyme';
+
+it('renders without crashing', () => {
+  const msa = mount(<MSAViewer sequences={[...dummySequences]} layout="basic" />);
+  expect(msa).toMatchSnapshot();
+});
+

--- a/src/components/layouts/compact.js
+++ b/src/components/layouts/compact.js
@@ -1,0 +1,36 @@
+/**
+* Copyright 2018, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+import React from 'react';
+
+import {
+  Labels,
+  OverviewBar,
+  PositionBar,
+  SequenceViewer,
+} from '../index';
+
+import PureBaseLayout from './PureBaseLayout';
+import msaConnect from '../../store/connect';
+
+class MSACompactLayout extends PureBaseLayout {
+  render() {
+    return (
+      <div>
+        <PositionBar {...this.props.positionBarProps} />
+        <SequenceViewer {...this.props.sequenceViewerProps} />
+      </div>
+    );
+  }
+}
+
+MSACompactLayout.propTypes = {
+  ...PureBaseLayout.propTypes,
+};
+
+export default MSACompactLayout;

--- a/src/components/layouts/compact.test.js
+++ b/src/components/layouts/compact.test.js
@@ -1,0 +1,21 @@
+/**
+* Copyright 2018, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+import React from 'react';
+import MSAViewer from '../MSAViewer';
+import dummySequences from '../../test/dummySequences';
+
+import {
+  mount
+} from 'enzyme';
+
+it('renders without crashing', () => {
+  const msa = mount(<MSAViewer sequences={[...dummySequences]} layout="compact" />);
+  expect(msa).toMatchSnapshot();
+});
+

--- a/src/components/layouts/full.js
+++ b/src/components/layouts/full.js
@@ -1,0 +1,45 @@
+/**
+* Copyright 2018, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+import React from 'react';
+
+import {
+  Labels,
+  OverviewBar,
+  PositionBar,
+  SequenceViewer,
+} from '../index';
+
+import PureBaseLayout from './PureBaseLayout';
+import msaConnect from '../../store/connect';
+
+class MSAFullLayout extends PureBaseLayout {
+  render() {
+    return (
+      <div style={{display: "flex"}}>
+        <Labels {...this.props.labelsProps} />
+        <div>
+          <SequenceViewer/>
+          <PositionBar {...this.props.positionBarProps} />
+          <br/>
+          <OverviewBar {...this.props.overviewBarProps} />
+          <br/>
+          <PositionBar {...this.props.positionBarProps} />
+          <OverviewBar
+          />
+          <OverviewBar
+            {...this.props.overviewBarProps}
+            method="information-content"
+          />
+        </div>
+      </div>
+    );
+  }
+}
+
+export default MSAFullLayout;

--- a/src/components/layouts/full.test.js
+++ b/src/components/layouts/full.test.js
@@ -1,0 +1,21 @@
+/**
+* Copyright 2018, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+import React from 'react';
+import MSAViewer from '../MSAViewer';
+import dummySequences from '../../test/dummySequences';
+
+import {
+  mount
+} from 'enzyme';
+
+it('renders without crashing', () => {
+  const msa = mount(<MSAViewer sequences={[...dummySequences]} layout="full" />);
+  expect(msa).toMatchSnapshot();
+});
+

--- a/src/components/layouts/funky.js
+++ b/src/components/layouts/funky.js
@@ -1,0 +1,59 @@
+/**
+* Copyright 2018, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+import React from 'react';
+
+import {
+  Labels,
+  OverviewBar,
+  PositionBar,
+  SequenceViewer,
+} from '../index';
+
+import PureBaseLayout from './PureBaseLayout';
+import msaConnect from '../../store/connect';
+
+class MSAFunkyLayout extends PureBaseLayout {
+  render() {
+    const labelsStyle = {
+      paddingTop: this.props.tileHeight,
+    }
+    return (
+      <div style={{display: "flex"}} >
+        <Labels
+          style={labelsStyle}
+        />
+        <div>
+          <PositionBar {...this.props.positionBarProps} />
+          <SequenceViewer {...this.props.sequenceViewerProps} />
+          <PositionBar {...this.props.positionBarProps} />
+          <OverviewBar {...this.props.overviewBarProps} />
+          <br/>
+          <PositionBar {...this.props.positionBarProps} />
+        </div>
+        <Labels
+          style={labelsStyle}
+          {...this.props.labelsProps}
+        />
+      </div>
+    );
+  }
+}
+MSAFunkyLayout.propTypes = {
+  ...PureBaseLayout.propTypes,
+};
+
+const mapStateToProps = state => {
+  return {
+    tileHeight: state.props.tileHeight,
+  }
+}
+
+export default msaConnect(
+  mapStateToProps,
+)(MSAFunkyLayout);

--- a/src/components/layouts/funky.test.js
+++ b/src/components/layouts/funky.test.js
@@ -1,0 +1,21 @@
+/**
+* Copyright 2018, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+import React from 'react';
+import MSAViewer from '../MSAViewer';
+import dummySequences from '../../test/dummySequences';
+
+import {
+  mount
+} from 'enzyme';
+
+it('renders without crashing', () => {
+  const msa = mount(<MSAViewer sequences={[...dummySequences]} layout="funky" />);
+  expect(msa).toMatchSnapshot();
+});
+

--- a/src/components/layouts/inverse.js
+++ b/src/components/layouts/inverse.js
@@ -1,0 +1,59 @@
+/**
+* Copyright 2018, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+import React from 'react';
+
+import {
+  Labels,
+  OverviewBar,
+  PositionBar,
+  SequenceViewer,
+} from '../index';
+
+import PureBaseLayout from './PureBaseLayout';
+import msaConnect from '../../store/connect';
+
+class MSAInverseLayout extends PureBaseLayout {
+  render() {
+    const labelsPadding = this.props.tileHeight;
+    const overviewBarHeight = 50;
+    const labelsStyle = {
+      paddingTop: labelsPadding + overviewBarHeight,
+    }
+    return (
+      <div style={{display: "flex"}} >
+          <div>
+            <OverviewBar
+              height={overviewBarHeight}
+              {...this.props.overviewBarProps}
+            />
+            <PositionBar {...this.props.positionBarProps} />
+            <SequenceViewer {...this.props.sequenceViewerProps} />
+          </div>
+          <Labels
+            style={labelsStyle}
+            {...this.props.labelsProps}
+          />
+        </div>
+    );
+    //<SequenceOverview />
+  }
+}
+MSAInverseLayout.propTypes = {
+  ...PureBaseLayout.propTypes,
+};
+
+const mapStateToProps = state => {
+  return {
+    tileHeight: state.props.tileHeight,
+  }
+}
+
+export default msaConnect(
+  mapStateToProps,
+)(MSAInverseLayout);

--- a/src/components/layouts/inverse.test.js
+++ b/src/components/layouts/inverse.test.js
@@ -1,0 +1,21 @@
+/**
+* Copyright 2018, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+import React from 'react';
+import MSAViewer from '../MSAViewer';
+import dummySequences from '../../test/dummySequences';
+
+import {
+  mount
+} from 'enzyme';
+
+it('renders without crashing', () => {
+  const msa = mount(<MSAViewer sequences={[...dummySequences]} layout="inverse" />);
+  expect(msa).toMatchSnapshot();
+});
+

--- a/src/components/layouts/util.js
+++ b/src/components/layouts/util.js
@@ -1,0 +1,66 @@
+/**
+* Copyright 2018, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+import {
+  forOwn,
+} from 'lodash-es'
+
+export const same = "FORWARD_SAME_PROP_NAME";
+
+/**
+ * Selects properties from a `props` object based on a
+ * propsSelector object map.
+ * @param {object} props The property object to select from
+ * @param {object} propsSelector The map object with which
+ *                               properties to forward
+ * Example:
+ * ```
+ * forwardProps({a: 1, b: 2, c: 3}, {b: "myB", c: same})
+ * // {forward: {myB: 2, c: 3}, other: {a: 1}}
+ * ```
+ */
+export function forwardProps(props, propsSelector) {
+  const forward = {};
+  const other = {};
+  forOwn(props, (v, k) => {
+    if (k in propsSelector) {
+      const forwardedName = propsSelector[k];
+      const name = forwardedName === same ? k : forwardedName;
+      forward[name] = v;
+    } else {
+      other[k] = v;
+    }
+  });
+  return {forward, other};
+}
+
+/**
+ * Uses a forward map to split a property object into pieces for
+ * respective sub components as `forwarded` and
+ * returns the remaining properties as `other`.
+ *
+ * @param {object} props The property object to split into pieces
+ * @param {object} propsToForward The nested forward map object
+ *
+ * Example:
+ * ```
+ * forwardProps({a: 1, b: 2, c: 3},
+ *              {myMapperA: {b: "myB"}, myMapperB: {c: same}})
+ * // {forward: {myMapper: {myB: 2}, myMapperB: {c: 3}}, other: {a: 1}}
+ * ```
+ */
+export function forwardPropsMapper(props, propsToForward) {
+  const forward = {};
+  let remainingProps = props;
+  forOwn(propsToForward, (v, k) => {
+    const result = forwardProps(remainingProps, v);
+    forward[k] = result.forward;
+    remainingProps = result.other;
+  });
+  return {forward, other: remainingProps};
+}

--- a/src/components/layouts/util.test.js
+++ b/src/components/layouts/util.test.js
@@ -1,0 +1,114 @@
+/**
+* Copyright 2018, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+import {
+  forwardProps,
+  forwardPropsMapper,
+  same,
+} from './util';
+
+describe("It should forward properties properly", () => {
+  it("should split correctly with forwardProps", () => {
+    const result = forwardProps({a: 1, b: 2, c: 3}, {b: "myB"});
+    expect(result).toEqual({forward: {myB: 2}, other: {a: 1, c: 3}});
+  });
+
+  it("should split correctly with forwardProps (including same)", () => {
+    const result = forwardProps({a: 1, b: 2, c: 3}, {b: "myB", c: same});
+    expect(result).toEqual({forward: {myB: 2, c: 3}, other: {a: 1}});
+  });
+});
+
+describe("selectForwardProps", () => {
+  it("should split a map correctly with one selector", () => {
+    const props = {a: 1, b: 2, c: 3};
+    const result = forwardPropsMapper(props, {
+      myFirstSelector: {
+        b: "myB",
+      },
+    });
+    expect(result).toEqual({
+      forward: {
+        myFirstSelector: {
+          myB: 2,
+        }
+      },
+      other: {
+        a: 1,
+        c: 3,
+      }
+    });
+  });
+  it("should split a map correctly with multiple selectors", () => {
+    const props = {a: 1, b: 2, c: 3};
+    const result = forwardPropsMapper(props, {
+      myFirstSelector: {
+        b: "myB",
+      },
+      mySecondSelector: {
+        c: same,
+      },
+    });
+    expect(result).toEqual({
+      forward: {
+        myFirstSelector: {
+          myB: 2,
+        },
+        mySecondSelector: {
+          c: 3,
+        }
+      },
+      other: {
+        a: 1,
+      },
+    });
+  });
+  it("should split a map correctly when no props are forward", () => {
+    const props = {a: 1};
+    const result = forwardPropsMapper(props, {
+      myFirstSelector: {
+        b: "myB",
+      },
+      mySecondSelector: {
+        c: same,
+      },
+    });
+    expect(result).toEqual({
+      forward: {
+        myFirstSelector: {},
+        mySecondSelector: {}
+      },
+      other: {
+        a: 1,
+      },
+    });
+  });
+  it("should split a map correctly when no props are remaining to be forwarded", () => {
+    const props = {b: 2, c: 3};
+    const result = forwardPropsMapper(props, {
+      myFirstSelector: {
+        b: "myB",
+      },
+      mySecondSelector: {
+        c: same,
+      },
+    });
+    expect(result).toEqual({
+      forward: {
+        myFirstSelector: {
+          myB: 2,
+        },
+        mySecondSelector: {
+          c: 3,
+        },
+      },
+      other: {},
+    });
+  });
+});
+

--- a/src/store/propsToRedux.js
+++ b/src/store/propsToRedux.js
@@ -13,6 +13,7 @@
 
 import React, { Component } from 'react';
 import createRef from 'create-react-ref/lib/createRef';
+import PropTypes from 'prop-types';
 
 import {
   forOwn,
@@ -23,7 +24,7 @@ import {
 } from 'lodash-es';
 
 import createMSAStore from './createMSAStore';
-import {MSAPropTypes, PropTypes} from '../PropTypes';
+import { MSAPropTypes } from '../PropTypes';
 import mainStoreActions from './actions';
 import { actions as positionStoreActions } from './positionReducers';
 import requestAnimation from '../utils/requestAnimation';


### PR DESCRIPTION
- MSAViewer gets dumber and just forwards everything unknown to MSALayouter
- MSALayouter creates a forwardObject of the passed in properties with `forwardPropsMapper` for all components and passes it into the layout
- PureBaseLayout provides a `shouldComponentUpdate` method that is similar to `React.PureComponent`, but shallowly looks into the forwarded property one level deeper (otherwise no re-render would be triggered)
- MSALayouter is pure and provides `dispatchEvent`, s.t. for the MSAViewer can abstract DOM node event dispatching nicely
- Individual layout can connect themselves to the redux store for global property updates

TODO: 
- [x] add more default layouts